### PR TITLE
Removing abusive usage of coerce

### DIFF
--- a/modules/core/src/main/scala/shop/algebras/auth.scala
+++ b/modules/core/src/main/scala/shop/algebras/auth.scala
@@ -7,7 +7,6 @@ import dev.profunktor.auth.jwt.JwtToken
 import dev.profunktor.redis4cats.algebra.RedisCommands
 import io.circe.syntax._
 import io.circe.parser.decode
-import io.estatico.newtype.ops._
 import pdi.jwt.JwtClaim
 import shop.config.data.TokenExpiration
 import shop.domain.auth._
@@ -65,7 +64,7 @@ class LiveUsersAuth[F[_]: Functor](
     redis
       .get(token.value)
       .map(_.flatMap { u =>
-        decode[User](u).toOption.map(_.coerce[CommonUser])
+        decode[User](u).toOption.map(CommonUser.apply)
       })
 
 }

--- a/modules/core/src/main/scala/shop/algebras/healthcheck.scala
+++ b/modules/core/src/main/scala/shop/algebras/healthcheck.scala
@@ -5,7 +5,6 @@ import cats.effect._
 import cats.effect.implicits._
 import cats.implicits._
 import dev.profunktor.redis4cats.algebra.RedisCommands
-import io.estatico.newtype.ops._
 import scala.concurrent.duration._
 import shop.domain.healthcheck._
 import skunk._
@@ -39,7 +38,7 @@ final class LiveHealthCheck[F[_]: Concurrent: Parallel: Timer] private (
       .map(_.nonEmpty)
       .timeout(1.second)
       .orElse(false.pure[F])
-      .map(_.coerce[RedisStatus])
+      .map(RedisStatus.apply)
 
   val postgresHealth: F[PostgresStatus] =
     sessionPool
@@ -47,7 +46,7 @@ final class LiveHealthCheck[F[_]: Concurrent: Parallel: Timer] private (
       .map(_.nonEmpty)
       .timeout(1.second)
       .orElse(false.pure[F])
-      .map(_.coerce[PostgresStatus])
+      .map(PostgresStatus.apply)
 
   val status: F[AppStatus] =
     (redisHealth, postgresHealth).parMapN(AppStatus)

--- a/modules/core/src/main/scala/shop/algebras/items.scala
+++ b/modules/core/src/main/scala/shop/algebras/items.scala
@@ -2,7 +2,6 @@ package shop.algebras
 
 import cats.effect._
 import cats.implicits._
-import io.estatico.newtype.ops._
 import shop.domain.brand.Brand
 import shop.domain.category._
 import shop.domain.brand._
@@ -76,12 +75,12 @@ private object ItemQueries {
     (uuid ~ varchar ~ varchar ~ numeric ~ uuid ~ varchar ~ uuid ~ varchar).map {
       case i ~ n ~ d ~ p ~ bi ~ bn ~ ci ~ cn =>
         Item(
-          i.coerce[ItemId],
-          n.coerce[ItemName],
-          d.coerce[ItemDescription],
-          p.coerce[USD],
-          Brand(bi.coerce[BrandId], bn.coerce[BrandName]),
-          Category(ci.coerce[CategoryId], cn.coerce[CategoryName])
+          ItemId(i),
+          ItemName(n),
+          ItemDescription(d),
+          USD(p),
+          Brand(BrandId(bi), BrandName(bn)),
+          Category(CategoryId(ci), CategoryName(cn))
         )
     }
 

--- a/modules/core/src/main/scala/shop/config/loader.scala
+++ b/modules/core/src/main/scala/shop/config/loader.scala
@@ -9,7 +9,6 @@ import environments.AppEnvironment._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString
-import io.estatico.newtype.ops._
 import scala.concurrent.duration._
 import shop.config.data._
 
@@ -46,14 +45,14 @@ object load {
     ).parMapN { (secretKey, claimStr, tokenKey, adminToken, salt) =>
       AppConfig(
         AdminJwtConfig(
-          secretKey.coerce[JwtSecretKeyConfig],
-          claimStr.coerce[JwtClaimConfig],
-          adminToken.coerce[AdminUserTokenConfig]
+          JwtSecretKeyConfig(secretKey),
+          JwtClaimConfig(claimStr),
+          AdminUserTokenConfig(adminToken)
         ),
-        tokenKey.coerce[JwtSecretKeyConfig],
-        salt.coerce[PasswordSalt],
-        30.minutes.coerce[TokenExpiration],
-        30.minutes.coerce[ShoppingCartExpiration],
+        JwtSecretKeyConfig(tokenKey),
+        PasswordSalt(salt),
+        TokenExpiration(30.minutes),
+        ShoppingCartExpiration(30.minutes),
         CheckoutConfig(
           retriesLimit = 3,
           retriesBackoff = 10.milliseconds

--- a/modules/core/src/main/scala/shop/domain/auth.scala
+++ b/modules/core/src/main/scala/shop/domain/auth.scala
@@ -2,7 +2,6 @@ package shop.domain
 
 import eu.timepit.refined.types.string.NonEmptyString
 import io.estatico.newtype.macros.newtype
-import io.estatico.newtype.ops._
 import java.util.UUID
 import javax.crypto.Cipher
 import scala.util.control.NoStackTrace
@@ -21,11 +20,11 @@ object auth {
   // --------- user registration -----------
 
   @newtype case class UserNameParam(value: NonEmptyString) {
-    def toDomain: UserName = value.value.toLowerCase.coerce[UserName]
+    def toDomain: UserName = UserName(value.value.toLowerCase)
   }
 
   @newtype case class PasswordParam(value: NonEmptyString) {
-    def toDomain: Password = value.value.coerce[Password]
+    def toDomain: Password = Password(value.value)
   }
 
   case class CreateUser(

--- a/modules/core/src/main/scala/shop/domain/brand.scala
+++ b/modules/core/src/main/scala/shop/domain/brand.scala
@@ -2,7 +2,6 @@ package shop.domain
 
 import eu.timepit.refined.types.string.NonEmptyString
 import io.estatico.newtype.macros.newtype
-import io.estatico.newtype.ops._
 import java.util.UUID
 import scala.util.control.NoStackTrace
 
@@ -15,7 +14,7 @@ object brand {
   }
 
   @newtype case class BrandParam(value: NonEmptyString) {
-    def toDomain: BrandName = value.value.toLowerCase.capitalize.coerce[BrandName]
+    def toDomain: BrandName = BrandName(value.value.toLowerCase.capitalize)
   }
 
   case class Brand(uuid: BrandId, name: BrandName)

--- a/modules/core/src/main/scala/shop/domain/category.scala
+++ b/modules/core/src/main/scala/shop/domain/category.scala
@@ -2,7 +2,6 @@ package shop.domain
 
 import eu.timepit.refined.types.string.NonEmptyString
 import io.estatico.newtype.macros.newtype
-import io.estatico.newtype.ops._
 import java.util.UUID
 
 object category {
@@ -10,7 +9,7 @@ object category {
   @newtype case class CategoryName(value: String)
 
   @newtype case class CategoryParam(value: NonEmptyString) {
-    def toDomain: CategoryName = value.value.toLowerCase.capitalize.coerce[CategoryName]
+    def toDomain: CategoryName = CategoryName(value.value.toLowerCase.capitalize)
   }
 
   case class Category(uuid: CategoryId, name: CategoryName)

--- a/modules/core/src/main/scala/shop/domain/item.scala
+++ b/modules/core/src/main/scala/shop/domain/item.scala
@@ -4,7 +4,6 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.{ Uuid, ValidBigDecimal }
 import eu.timepit.refined.types.string.NonEmptyString
 import io.estatico.newtype.macros.newtype
-import io.estatico.newtype.ops._
 import java.util.UUID
 //import squants.market.USD
 import shop.domain.brand._
@@ -40,8 +39,8 @@ object item {
   ) {
     def toDomain: CreateItem =
       CreateItem(
-        name.value.value.coerce[ItemName],
-        description.value.value.coerce[ItemDescription],
+        ItemName(name.value.value),
+        ItemDescription(description.value.value),
         price,
         brandId,
         categoryId
@@ -67,8 +66,8 @@ object item {
   ) {
     def toDomain: UpdateItem =
       UpdateItem(
-        UUID.fromString(id.value.value).coerce[ItemId],
-        BigDecimal(price.value.value).coerce[USD]
+        ItemId(UUID.fromString(id.value.value)),
+        USD(BigDecimal(price.value.value))
       )
   }
 

--- a/modules/core/src/main/scala/shop/http/routes/secured/CartRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/secured/CartRoutes.scala
@@ -2,7 +2,6 @@ package shop.http.routes.secured
 
 import cats.effect.Sync
 import cats.implicits._
-import io.estatico.newtype.ops._
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server._
@@ -43,7 +42,7 @@ final class CartRoutes[F[_]: Sync](
 
     // Remove item from the cart
     case DELETE -> Root / UUIDVar(uuid) as user =>
-      shoppingCart.removeItem(user.value.id, uuid.coerce[ItemId]) *> NoContent()
+      shoppingCart.removeItem(user.value.id, ItemId(uuid)) *> NoContent()
   }
 
   def routes(authMiddleware: AuthMiddleware[F, CommonUser]): HttpRoutes[F] = Router(

--- a/modules/core/src/main/scala/shop/http/routes/secured/OrderRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/secured/OrderRoutes.scala
@@ -1,7 +1,6 @@
 package shop.http.routes.secured
 
 import cats.effect.Sync
-import io.estatico.newtype.ops._
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server._
@@ -22,7 +21,7 @@ final class OrderRoutes[F[_]: Sync](
       Ok(orders.findBy(user.value.id))
 
     case GET -> Root / UUIDVar(orderId) as user =>
-      Ok(orders.get(user.value.id, orderId.coerce[OrderId]))
+      Ok(orders.get(user.value.id, OrderId(orderId)))
 
   }
 

--- a/modules/tests/src/main/scala/shop/generators.scala
+++ b/modules/tests/src/main/scala/shop/generators.scala
@@ -81,6 +81,6 @@ object generators {
       u <- Gen.posNum[Long].map[CardNumberPred](Refined.unsafeApply)
       x <- Gen.posNum[Int].map[CardExpirationPred](x => Refined.unsafeApply(x.toString))
       c <- Gen.posNum[Int].map[CardCCVPred](Refined.unsafeApply)
-    } yield Card(n.coerce[CardName], u.coerce[CardNumber], x.coerce[CardExpiration], c.coerce[CardCCV])
+    } yield Card(CardName(n), CardNumber(u), CardExpiration(x), CardCCV(c))
 
 }

--- a/modules/tests/src/test/scala/shop/http/routes/secured/CartRoutesSpec.scala
+++ b/modules/tests/src/test/scala/shop/http/routes/secured/CartRoutesSpec.scala
@@ -2,7 +2,6 @@ package shop.http.routes.secured
 
 import cats.data.Kleisli
 import cats.effect._
-import io.estatico.newtype.ops._
 import java.util.UUID
 import org.http4s._
 import org.http4s.Method._
@@ -19,7 +18,7 @@ import suite.HttpTestSuite
 
 class CartRoutesSpec extends HttpTestSuite {
 
-  val authUser = User(UUID.randomUUID.coerce[UserId], "user".coerce[UserName]).coerce[CommonUser]
+  val authUser = CommonUser(User(UserId(UUID.randomUUID), UserName("user")))
 
   val authMiddleware: AuthMiddleware[IO, CommonUser] =
     AuthMiddleware(Kleisli.pure(authUser))


### PR DESCRIPTION
The `coerce` method should only be used in generic cases when the concrete type is not known. In any other circumstance, we should just use `apply`.

Moreover, `coerce` is implemented using `asInstanceOf`, yet another reason not to use it when we know the concrete type.

Merging once I update the book with these changes.