### PR TITLE
Fixing Background implementation

### DIFF
--- a/modules/core/src/main/scala/shop/effects/Background.scala
+++ b/modules/core/src/main/scala/shop/effects/Background.scala
@@ -26,6 +26,8 @@ object Background {
         Deferred[F, Unit].flatMap { gate =>
           (Timer[F].sleep(duration) *> fa.guarantee(gate.complete(()))).start
             .bracket(_ => gate.get)(_.cancel)
+            .start
+            .void
         }
 
     }


### PR DESCRIPTION
As reported by @calvinlfer, 

Using `bracket` with `F.never` and `_.cancel` on release guarantees that the Fiber is canceled in case of interruption, however, in case of success, the program never ends.

To fix this, I introduced a `Deferred` that is guaranteed to be completed in case of success and failure. 