### PR TITLE
First optimization of docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,16 @@ docker build modules/core/target/docker/stage/ -t shopping-cart
 Our image should now be built. We can check it by running the following command:
 
 ```
-> docker images
+> docker images | grep shopping-cart
 REPOSITORY                    TAG                 IMAGE ID            CREATED              SIZE
-shopping-cart                 latest              e836c97e5673        About a minute ago   541MB
+shopping-cart                 latest              646501a87362        2 seconds ago       138MB
 ```
 
 To run our application using our Docker image, run the following command:
 
 ```
-docker run --network="host" shopping-cart
+cd /app
+docker-compose up
 ```
 
 ## HTTP API Resources

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ export SC_APP_ENV="test"
 ### Build Docker image
 
 ```
-sbt docker:stage
-docker build modules/core/target/docker/stage/ -t shopping-cart
+sbt docker:publishLocal
 ```
 
 Our image should now be built. We can check it by running the following command:

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.4'
+services:
+  shopping_cart:
+    restart: always
+    image: shopping-cart:latest
+    network_mode: host
+    ports:
+      - "8080:8080"
+    environment:
+      - DEBUG=false
+      - SC_ACCESS_TOKEN_SECRET_KEY=5h0pp1ng_k4rt
+      - SC_JWT_SECRET_KEY=-*5h0pp1ng_k4rt*-
+      - SC_JWT_CLAIM={004b4457-71c3-4439-a1b2-03820263b59c}
+      - SC_ADMIN_USER_TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.ezA0YjQ0NTctNzFjMy00NDM5LWExYjItMDM4MjAyNjNiNTl9.mMC4eiPl7huiAO3GdORwKnqJrf96xKPoojQdZtrTbP4
+      - SC_PASSWORD_SALT=06!grsnxXG0d*Pj496p6fuA*o
+      - SC_APP_ENV=test

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val core = (project in file("modules/core"))
   .enablePlugins(AshScriptPlugin)
   .settings(
     name := "shopping-cart-core",
-    packageName := "shopping-cart",
+    packageName in Docker := "shopping-cart",
     scalacOptions += "-Ymacro-annotations",
     scalafmtOnCompile := true,
     resolvers += Resolver.sonatypeRepo("snapshots"),
@@ -43,6 +43,7 @@ lazy val core = (project in file("modules/core"))
     dockerBaseImage := "openjdk:8u201-jre-alpine3.9",
     dockerExposedPorts ++= Seq(8080),
     makeBatScripts := Seq(),
+    dockerUpdateLatest := true,
     libraryDependencies ++= Seq(
       compilerPlugin(Libraries.kindProjector cross CrossVersion.full),
       compilerPlugin(Libraries.betterMonadicFor),

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ lazy val core = (project in file("modules/core"))
     Defaults.itSettings,
     dockerBaseImage := "openjdk:8u201-jre-alpine3.9",
     dockerExposedPorts ++= Seq(8080),
+    makeBatScripts := Seq(),
     libraryDependencies ++= Seq(
       compilerPlugin(Libraries.kindProjector cross CrossVersion.full),
       compilerPlugin(Libraries.betterMonadicFor),

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ lazy val tests = (project in file("modules/tests"))
 lazy val core = (project in file("modules/core"))
   .enablePlugins(JavaAppPackaging)
   .enablePlugins(DockerPlugin)
+  .enablePlugins(AshScriptPlugin)
   .settings(
     name := "shopping-cart-core",
     packageName := "shopping-cart",
@@ -39,15 +40,8 @@ lazy val core = (project in file("modules/core"))
     scalafmtOnCompile := true,
     resolvers += Resolver.sonatypeRepo("snapshots"),
     Defaults.itSettings,
+    dockerBaseImage := "openjdk:8u201-jre-alpine3.9",
     dockerExposedPorts ++= Seq(8080),
-    dockerEnvVars ++= Map(
-      "SC_APP_ENV" -> System.getenv("SC_APP_ENV"),
-      "SC_JWT_CLAIM" -> System.getenv("SC_JWT_CLAIM"),
-      "SC_JWT_SECRET_KEY" -> System.getenv("SC_JWT_SECRET_KEY"),
-      "SC_PASSWORD_SALT" -> System.getenv("SC_PASSWORD_SALT"),
-      "SC_ACCESS_TOKEN_SECRET_KEY" -> System.getenv("SC_ACCESS_TOKEN_SECRET_KEY"),
-      "SC_ADMIN_USER_TOKEN" -> System.getenv("SC_ADMIN_USER_TOKEN")
-    ),
     libraryDependencies ++= Seq(
       compilerPlugin(Libraries.kindProjector cross CrossVersion.full),
       compilerPlugin(Libraries.betterMonadicFor),


### PR DESCRIPTION
closes #19 

@calvinlfer I managed to reduce the image to 138 MBs with the JRE image. The one you suggested has the JDK which is not needed to run the application and it generates an image of size 208 MBs.

This is the first optimization and I believe that we can make it even smaller. In the slides of the talk I suggested in the issue there are some tricks we can take :)

I also removed the environment variables from the `build.sbt` and created a `docker-compose` file to run the application straightforwardly. 