### PR TITLE
Using Cats Equality

### DIFF
--- a/modules/core/src/main/scala/shop/domain/package.scala
+++ b/modules/core/src/main/scala/shop/domain/package.scala
@@ -1,0 +1,27 @@
+package shop
+
+import cats.Eq
+import cats.implicits._
+import io.estatico.newtype.Coercible
+import io.estatico.newtype.ops._
+import java.util.UUID
+
+package object domain {
+
+  // does not work as implicit for some reason...
+  private def coercibleEq[A: Eq, B: Coercible[A, *]]: Eq[B] =
+    new Eq[B] {
+      def eqv(x: B, y: B): Boolean =
+        Eq[A].eqv(x.repr.asInstanceOf[A], y.repr.asInstanceOf[A])
+    }
+
+  implicit def coercibleStringEq[B: Coercible[String, *]]: Eq[B] =
+    coercibleEq[String, B]
+
+  implicit def coercibleUuidEq[B: Coercible[UUID, *]]: Eq[B] =
+    coercibleEq[UUID, B]
+
+  implicit def coercibleIntEq[B: Coercible[Int, *]]: Eq[B] =
+    coercibleEq[Int, B]
+
+}

--- a/modules/tests/src/it/scala/shop/algebras/PostgresTest.scala
+++ b/modules/tests/src/it/scala/shop/algebras/PostgresTest.scala
@@ -1,7 +1,7 @@
 package shop.algebras
 
 import cats.effect._
-import cats.implicits._
+import cats.implicits.{ catsSyntaxEq => _, _ }
 import ciris._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
@@ -47,7 +47,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           z <- b.create(brand.name).attempt
         } yield
           assert(
-            x.isEmpty && y.count(_.name == brand.name) == 1 && z.isLeft
+            x.isEmpty && y.count(_.name === brand.name) === 1 && z.isLeft
           )
       }
     }
@@ -62,7 +62,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           z <- c.create(category.name).attempt
         } yield
           assert(
-            x.isEmpty && y.count(_.name == category.name) == 1 && z.isLeft
+            x.isEmpty && y.count(_.name === category.name) === 1 && z.isLeft
           )
       }
     }
@@ -93,7 +93,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           y <- i.findAll
         } yield
           assert(
-            x.isEmpty && y.count(_.name == item.name) == 1
+            x.isEmpty && y.count(_.name === item.name) === 1
           )
       }
     }
@@ -109,7 +109,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           z <- u.create(username, password).attempt
         } yield
           assert(
-            x.count(_.id == d) == 1 && y.isEmpty && z.isLeft
+            x.count(_.id === d) === 1 && y.isEmpty && z.isLeft
           )
       }
     }
@@ -126,7 +126,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           i <- o.create(d, pid, items, price)
         } yield
           assert(
-            x.isEmpty && y.isEmpty && i.value.version == 4
+            x.isEmpty && y.isEmpty && i.value.version === 4
           )
       }
     }

--- a/modules/tests/src/it/scala/shop/algebras/PostgresTest.scala
+++ b/modules/tests/src/it/scala/shop/algebras/PostgresTest.scala
@@ -1,7 +1,7 @@
 package shop.algebras
 
 import cats.effect._
-import cats.implicits.{ catsSyntaxEq => _, _ }
+import cats.implicits._
 import ciris._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
@@ -10,6 +10,7 @@ import io.estatico.newtype.ops._
 import natchez.Trace.Implicits.noop // needed for skunk
 import shop.arbitraries._
 import shop.config.data.PasswordSalt
+import shop.domain._
 import shop.domain.auth._
 import shop.domain.brand._
 import shop.domain.category._
@@ -47,7 +48,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           z <- b.create(brand.name).attempt
         } yield
           assert(
-            x.isEmpty && y.count(_.name === brand.name) === 1 && z.isLeft
+            x.isEmpty && y.count(_.name.eqv(brand.name)).eqv(1) && z.isLeft
           )
       }
     }
@@ -62,7 +63,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           z <- c.create(category.name).attempt
         } yield
           assert(
-            x.isEmpty && y.count(_.name === category.name) === 1 && z.isLeft
+            x.isEmpty && y.count(_.name.eqv(category.name)).eqv(1) && z.isLeft
           )
       }
     }
@@ -93,7 +94,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           y <- i.findAll
         } yield
           assert(
-            x.isEmpty && y.count(_.name === item.name) === 1
+            x.isEmpty && y.count(_.name.eqv(item.name)).eqv(1)
           )
       }
     }
@@ -109,7 +110,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           z <- u.create(username, password).attempt
         } yield
           assert(
-            x.count(_.id === d) === 1 && y.isEmpty && z.isLeft
+            x.count(_.id.eqv(d)).eqv(1) && y.isEmpty && z.isLeft
           )
       }
     }
@@ -126,7 +127,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           i <- o.create(d, pid, items, price)
         } yield
           assert(
-            x.isEmpty && y.isEmpty && i.value.version === 4
+            x.isEmpty && y.isEmpty && i.value.version.eqv(4)
           )
       }
     }

--- a/modules/tests/src/it/scala/shop/algebras/RedisTest.scala
+++ b/modules/tests/src/it/scala/shop/algebras/RedisTest.scala
@@ -2,7 +2,7 @@ package shop.algebras
 
 import cats.effect._
 import cats.effect.concurrent.Ref
-import cats.implicits.{ catsSyntaxEq => _, _ }
+import cats.implicits._
 import ciris.Secret
 import dev.profunktor.auth.jwt._
 import dev.profunktor.redis4cats.algebra.RedisCommands
@@ -19,6 +19,7 @@ import pdi.jwt._
 import scala.concurrent.duration._
 import shop.arbitraries._
 import shop.config.data._
+import shop.domain._
 import shop.domain.auth._
 import shop.domain.brand._
 import shop.domain.category._
@@ -65,9 +66,9 @@ class RedisTest extends ResourceSuite[RedisCommands[IO, String, String]] {
               v <- c.get(uid)
             } yield
               assert(
-                x.items.isEmpty && y.items.size === 2 &&
-                z.items.size == 1 && v.items.isEmpty &&
-                w.items.headOption.fold(false)(_.quantity === q2)
+                x.items.isEmpty && y.items.size.eqv(2) &&
+                z.items.size.eqv(1) && v.items.isEmpty &&
+                w.items.headOption.fold(false)(_.quantity.eqv(q2))
               )
           }
         }
@@ -91,7 +92,7 @@ class RedisTest extends ResourceSuite[RedisCommands[IO, String, String]] {
         } yield
           assert(
             x.isEmpty && e.isRight && f.isRight && y.isEmpty &&
-            w.fold(false)(_.value.name === un1)
+            w.fold(false)(_.value.name.eqv(un1))
           )
       }
     }

--- a/modules/tests/src/it/scala/shop/algebras/RedisTest.scala
+++ b/modules/tests/src/it/scala/shop/algebras/RedisTest.scala
@@ -102,7 +102,7 @@ class RedisTest extends ResourceSuite[RedisCommands[IO, String, String]] {
 
 protected class TestUsers(un: UserName) extends Users[IO] {
   def find(username: UserName, password: Password): IO[Option[User]] =
-    (username == un).guard[Option].as(User(UUID.randomUUID.coerce[UserId], un)).pure[IO]
+    (username.eqv(un)).guard[Option].as(User(UUID.randomUUID.coerce[UserId], un)).pure[IO]
   def create(username: UserName, password: Password): IO[UserId] =
     GenUUID[IO].make[UserId]
 }

--- a/modules/tests/src/it/scala/shop/algebras/RedisTest.scala
+++ b/modules/tests/src/it/scala/shop/algebras/RedisTest.scala
@@ -2,7 +2,7 @@ package shop.algebras
 
 import cats.effect._
 import cats.effect.concurrent.Ref
-import cats.implicits._
+import cats.implicits.{ catsSyntaxEq => _, _ }
 import ciris.Secret
 import dev.profunktor.auth.jwt._
 import dev.profunktor.redis4cats.algebra.RedisCommands
@@ -65,9 +65,9 @@ class RedisTest extends ResourceSuite[RedisCommands[IO, String, String]] {
               v <- c.get(uid)
             } yield
               assert(
-                x.items.isEmpty && y.items.size == 2 &&
+                x.items.isEmpty && y.items.size === 2 &&
                 z.items.size == 1 && v.items.isEmpty &&
-                w.items.headOption.fold(false)(_.quantity == q2)
+                w.items.headOption.fold(false)(_.quantity === q2)
               )
           }
         }
@@ -91,7 +91,7 @@ class RedisTest extends ResourceSuite[RedisCommands[IO, String, String]] {
         } yield
           assert(
             x.isEmpty && e.isRight && f.isRight && y.isEmpty &&
-            w.fold(false)(_.value.name == un1)
+            w.fold(false)(_.value.name === un1)
           )
       }
     }

--- a/modules/tests/src/main/scala/suite/http4stest.scala
+++ b/modules/tests/src/main/scala/suite/http4stest.scala
@@ -18,7 +18,7 @@ trait HttpTestSuite extends PureTestSuite {
     routes.run(req).value.flatMap {
       case Some(resp) =>
         resp.as[Json].map { json =>
-          assert(resp.status == expectedStatus && json.dropNullValues == expectedBody.asJson.dropNullValues)
+          assert(resp.status === expectedStatus && json.dropNullValues === expectedBody.asJson.dropNullValues)
         }
       case None => fail("route nout found")
     }
@@ -26,7 +26,7 @@ trait HttpTestSuite extends PureTestSuite {
   def assertHttpStatus(routes: HttpRoutes[IO], req: Request[IO])(expectedStatus: Status) =
     routes.run(req).value.map {
       case Some(resp) =>
-        assert(resp.status == expectedStatus)
+        assert(resp.status === expectedStatus)
       case None => fail("route nout found")
     }
 

--- a/modules/tests/src/main/scala/suite/http4stest.scala
+++ b/modules/tests/src/main/scala/suite/http4stest.scala
@@ -1,6 +1,7 @@
 package suite
 
 import cats.effect.IO
+import cats.implicits._
 import io.circe._
 import io.circe.syntax._
 import org.http4s._
@@ -18,7 +19,7 @@ trait HttpTestSuite extends PureTestSuite {
     routes.run(req).value.flatMap {
       case Some(resp) =>
         resp.as[Json].map { json =>
-          assert(resp.status === expectedStatus && json.dropNullValues === expectedBody.asJson.dropNullValues)
+          assert(resp.status.eqv(expectedStatus) && json.dropNullValues.eqv(expectedBody.asJson.dropNullValues))
         }
       case None => fail("route nout found")
     }
@@ -26,7 +27,7 @@ trait HttpTestSuite extends PureTestSuite {
   def assertHttpStatus(routes: HttpRoutes[IO], req: Request[IO])(expectedStatus: Status) =
     routes.run(req).value.map {
       case Some(resp) =>
-        assert(resp.status === expectedStatus)
+        assert(resp.status.eqv(expectedStatus))
       case None => fail("route nout found")
     }
 

--- a/modules/tests/src/test/scala/shop/programs/CheckoutSpec.scala
+++ b/modules/tests/src/test/scala/shop/programs/CheckoutSpec.scala
@@ -39,8 +39,8 @@ final class CheckoutSpec extends PureTestSuite {
     new PaymentClient[IO] {
       def process(userId: UserId, total: Money, card: Card): IO[PaymentId] =
         attemptsSoFar.get.flatMap {
-          case n if n == 1 => IO.pure(paymentId)
-          case _           => attemptsSoFar.update(_ + 1) *> IO.raiseError(PaymentError(""))
+          case n if n.eqv(1) => IO.pure(paymentId)
+          case _             => attemptsSoFar.update(_ + 1) *> IO.raiseError(PaymentError(""))
         }
     }
 

--- a/modules/tests/src/test/scala/shop/programs/CheckoutSpec.scala
+++ b/modules/tests/src/test/scala/shop/programs/CheckoutSpec.scala
@@ -2,7 +2,7 @@ package shop.programs
 
 import cats.effect._
 import cats.effect.concurrent.Ref
-import cats.implicits._
+import cats.implicits.{ catsSyntaxEq => _, _ }
 import retry.RetryPolicy
 import retry.RetryPolicies._
 import shop.algebras._
@@ -95,7 +95,7 @@ final class CheckoutSpec extends PureTestSuite {
           .flatMap {
             case Left(PaymentError(_)) =>
               logs.get.map {
-                case (x :: xs) => assert(x.contains("Giving up") && xs.size == MaxRetries)
+                case (x :: xs) => assert(x.contains("Giving up") && xs.size === MaxRetries)
                 case _         => fail(s"Expected $MaxRetries retries")
               }
             case _ => fail("Expected payment error")
@@ -116,7 +116,7 @@ final class CheckoutSpec extends PureTestSuite {
             .flatMap {
               case Right(id) =>
                 logs.get.map { xs =>
-                  assert(id == oid && xs.size == 1)
+                  assert(id === oid && xs.size === 1)
                 }
               case Left(_) => fail("Expected Payment Id")
             }
@@ -141,8 +141,8 @@ final class CheckoutSpec extends PureTestSuite {
                     assert(
                       x.contains("Rescheduling") &&
                         y.contains("Giving up") &&
-                        xs.size == MaxRetries &&
-                        c == 1
+                        xs.size === MaxRetries &&
+                        c === 1
                     )
                   case _ => fail(s"Expected $MaxRetries retries and reschedule")
                 }
@@ -161,7 +161,7 @@ final class CheckoutSpec extends PureTestSuite {
       new CheckoutProgram[IO](successfulClient(pid), failingCart(ct), successfulOrders(oid), retryPolicy)
         .checkout(uid, card)
         .map { id =>
-          assert(id == oid)
+          assert(id === oid)
         }
     }
   }
@@ -173,7 +173,7 @@ final class CheckoutSpec extends PureTestSuite {
       new CheckoutProgram[IO](successfulClient(pid), successfulCart(ct), successfulOrders(oid), retryPolicy)
         .checkout(uid, card)
         .map { id =>
-          assert(id == oid)
+          assert(id === oid)
         }
     }
   }


### PR DESCRIPTION
Better than using universal equality. Can't use `===` due to collision with Scalactic's `===` being in scope (brought by the suite mixin from Scalatest).