### PR TITLE
Introducing test payments client

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ cd /app
 docker-compose up
 ```
 
+## Payments Client
+
+The configured test payment client is a fake API that always returns 200 with a Payment Id. Users are encouraged to make modifications, e.g. return 409 with another Payment Id (you can create one [here](https://www.uuidgenerator.net/api/version1/1)) or any other HTTP status to see how our application handles the different cases.
+
+This fake API can be modified at: [https://beeceptor.com/console/payments](https://beeceptor.com/console/payments)
+
 ## HTTP API Resources
 
 If you use the [Insomnia](https://insomnia.rest/) REST Client, you can import the shopping cart resources using the [insomnia.json](insomnia.json) file.

--- a/modules/core/src/main/resources/tables.sql
+++ b/modules/core/src/main/resources/tables.sql
@@ -31,7 +31,7 @@ CREATE TABLE items (
 
 CREATE TABLE orders (
   uuid UUID PRIMARY KEY,
-  user_id UUID UNIQUE NOT NULL,
+  user_id UUID NOT NULL,
   payment_id UUID UNIQUE NOT NULL,
   items JSONB NOT NULL,
   total NUMERIC,

--- a/modules/core/src/main/scala/shop/config/loader.scala
+++ b/modules/core/src/main/scala/shop/config/loader.scala
@@ -22,7 +22,7 @@ object load {
         case Test =>
           default(
             redisUri = RedisURI("redis://localhost"),
-            paymentUri = PaymentURI("http://10.123.154.10/api")
+            paymentUri = PaymentURI("https://payments.free.beeceptor.com")
           )
         case Prod =>
           default(

--- a/modules/core/src/main/scala/shop/domain/payment.scala
+++ b/modules/core/src/main/scala/shop/domain/payment.scala
@@ -1,0 +1,15 @@
+package shop.domain
+
+import shop.domain.auth.UserId
+import shop.domain.checkout.Card
+import squants.market.Money
+
+object payment {
+
+  case class Payment(
+      id: UserId,
+      total: Money,
+      card: Card
+  )
+
+}

--- a/modules/core/src/main/scala/shop/http/clients/payments.scala
+++ b/modules/core/src/main/scala/shop/http/clients/payments.scala
@@ -22,9 +22,6 @@ final class LivePaymentClient[F[_]: JsonDecoder: MonadThrow](
 ) extends PaymentClient[F]
     with Http4sClientDsl[F] {
 
-  // Should not be necessary but Scala seems not to find the right implicits from `json.scala`
-  implicit val codec = jsonEncoderOf[F, Payment]
-
   def process(payment: Payment): F[PaymentId] =
     Uri.fromString(cfg.uri.value.value + "/payments").liftTo[F].flatMap { uri =>
       client.fetch[PaymentId](POST(payment, uri)) { r =>

--- a/modules/core/src/main/scala/shop/http/clients/payments.scala
+++ b/modules/core/src/main/scala/shop/http/clients/payments.scala
@@ -31,7 +31,9 @@ final class LivePaymentClient[F[_]: JsonDecoder: MonadThrow](
         if (r.status == Status.Ok || r.status == Status.Conflict)
           r.asJsonDecode[PaymentId]
         else
-          PaymentError(r.status.reason).raiseError[F, PaymentId]
+          PaymentError(
+            Option(r.status.reason).getOrElse("unknown")
+          ).raiseError[F, PaymentId]
       }
     }
 

--- a/modules/core/src/main/scala/shop/http/clients/payments.scala
+++ b/modules/core/src/main/scala/shop/http/clients/payments.scala
@@ -4,32 +4,35 @@ import cats.implicits._
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.client._
+import org.http4s.client.dsl.Http4sClientDsl
+import org.http4s.Method._
 import shop.config.data.PaymentConfig
-import shop.domain.auth.UserId
-import shop.domain.checkout.Card
 import shop.domain.order._
-import shop.effects._
+import shop.domain.payment._
 import shop.http.json._
-import squants.market.Money
+import shop.effects._
 
 trait PaymentClient[F[_]] {
-  def process(userId: UserId, total: Money, card: Card): F[PaymentId]
+  def process(payment: Payment): F[PaymentId]
 }
 
 final class LivePaymentClient[F[_]: JsonDecoder: MonadThrow](
     cfg: PaymentConfig,
     client: Client[F]
-) extends PaymentClient[F] {
+) extends PaymentClient[F]
+    with Http4sClientDsl[F] {
 
-  def process(userId: UserId, total: Money, card: Card): F[PaymentId] =
+  // Should not be necessary but Scala seems not to find the right implicits from `json.scala`
+  implicit val codec = jsonEncoderOf[F, Payment]
+
+  def process(payment: Payment): F[PaymentId] =
     Uri.fromString(cfg.uri.value.value + "/payments").liftTo[F].flatMap { uri =>
-      client
-        .get[PaymentId](uri) { r =>
-          if (r.status == Status.Ok || r.status == Status.Conflict)
-            r.asJsonDecode[PaymentId]
-          else
-            PaymentError(r.status.reason).raiseError[F, PaymentId]
-        }
+      client.fetch[PaymentId](POST(payment, uri)) { r =>
+        if (r.status == Status.Ok || r.status == Status.Conflict)
+          r.asJsonDecode[PaymentId]
+        else
+          PaymentError(r.status.reason).raiseError[F, PaymentId]
+      }
     }
 
 }

--- a/modules/core/src/main/scala/shop/http/json.scala
+++ b/modules/core/src/main/scala/shop/http/json.scala
@@ -33,6 +33,9 @@ object json {
   implicit val categoryParamDecoder: Decoder[CategoryParam] =
     Decoder.forProduct1("name")(CategoryParam.apply)
 
+  implicit val paymentIdDecoder: Decoder[PaymentId] =
+    Decoder.forProduct1("paymentId")(PaymentId.apply)
+
   // ----- Coercible codecs -----
   implicit def coercibleDecoder[A: Coercible[B, *], B: Decoder]: Decoder[A] =
     Decoder[B].map(_.coerce[A])

--- a/modules/core/src/main/scala/shop/http/json.scala
+++ b/modules/core/src/main/scala/shop/http/json.scala
@@ -17,6 +17,7 @@ import shop.domain.checkout._
 import shop.domain.healthcheck._
 import shop.domain.item._
 import shop.domain.order._
+import shop.domain.payment._
 import shop.ext.refined._
 import shop.http.auth.users._
 import squants.market._
@@ -73,6 +74,7 @@ object json {
   implicit val orderEncoder: Encoder[Order] = deriveEncoder[Order]
 
   implicit val cardDecoder: Decoder[Card] = deriveDecoder[Card]
+  implicit val cardEncoder: Encoder[Card] = deriveEncoder[Card]
 
   implicit val tokenEncoder: Encoder[JwtToken] =
     Encoder.forProduct1("access_token")(_.value)
@@ -85,6 +87,8 @@ object json {
 
   implicit val userDecoder: Decoder[User] = deriveDecoder[User]
   implicit val userEncoder: Encoder[User] = deriveEncoder[User]
+
+  implicit val paymentEncoder: Encoder[Payment] = deriveEncoder[Payment]
 
   implicit val appStatusEncoder: Encoder[AppStatus] = deriveEncoder[AppStatus]
 

--- a/modules/core/src/main/scala/shop/http/json.scala
+++ b/modules/core/src/main/scala/shop/http/json.scala
@@ -22,9 +22,14 @@ import shop.ext.refined._
 import shop.http.auth.users._
 import squants.market._
 
-object json {
-
+object json extends JsonCodecs {
   implicit def jsonEncoder[F[_]: Applicative, A: Encoder]: EntityEncoder[F, A] = jsonEncoderOf[F, A]
+
+  // Should not be necessary but Scala seems not to find the right implicits
+  implicit def codec[F[_]: Applicative] = jsonEncoderOf[F, Payment]
+}
+
+private[http] trait JsonCodecs {
 
   // ----- Overriding some Coercible codecs ----
   implicit val brandParamDecoder: Decoder[BrandParam] =

--- a/modules/core/src/main/scala/shop/http/routes/secured/CheckoutRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/secured/CheckoutRoutes.scala
@@ -6,11 +6,11 @@ import org.http4s._
 import org.http4s.circe.JsonDecoder
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server._
-import shop.http.auth.users.CommonUser
 import shop.domain.cart._
 import shop.domain.checkout._
 import shop.domain.order._
 import shop.effects._
+import shop.http.auth.users.CommonUser
 import shop.http.decoder._
 import shop.http.json._
 import shop.http.HttpRouter

--- a/modules/core/src/main/scala/shop/programs/checkout.scala
+++ b/modules/core/src/main/scala/shop/programs/checkout.scala
@@ -11,6 +11,7 @@ import shop.domain.auth.UserId
 import shop.domain.cart._
 import shop.domain.checkout._
 import shop.domain.order._
+import shop.domain.payment._
 import shop.effects._
 import shop.http.clients.PaymentClient
 import squants.market.Money
@@ -32,11 +33,11 @@ final class CheckoutProgram[F[_]: Background: Logger: MonadThrow: Timer](
         Logger[F].error(s"Giving up on $action after ${g.totalRetries} retries.")
     }
 
-  private def processPayment(userId: UserId, total: Money, card: Card): F[PaymentId] = {
+  private def processPayment(payment: Payment): F[PaymentId] = {
     val action = retryingOnAllErrors[PaymentId](
       policy = retryPolicy,
       onError = logError("Payments")
-    )(paymentClient.process(userId, total, card))
+    )(paymentClient.process(payment))
 
     action.adaptError {
       case e => PaymentError(e.getMessage)
@@ -67,7 +68,7 @@ final class CheckoutProgram[F[_]: Background: Logger: MonadThrow: Timer](
       .flatMap {
         case CartTotal(items, total) =>
           for {
-            pid <- processPayment(userId, total, card)
+            pid <- processPayment(Payment(userId, total, card))
             order <- createOrder(userId, pid, items, total)
             _ <- shoppingCart.delete(userId).attempt.void
           } yield order

--- a/modules/core/src/main/scala/shop/programs/checkout.scala
+++ b/modules/core/src/main/scala/shop/programs/checkout.scala
@@ -40,7 +40,8 @@ final class CheckoutProgram[F[_]: Background: Logger: MonadThrow: Timer](
     )(paymentClient.process(payment))
 
     action.adaptError {
-      case e => PaymentError(e.getMessage)
+      case e =>
+        PaymentError(Option(e.getMessage).getOrElse("Unknown"))
     }
   }
 

--- a/modules/tests/src/test/scala/shop/programs/CheckoutSpec.scala
+++ b/modules/tests/src/test/scala/shop/programs/CheckoutSpec.scala
@@ -13,6 +13,7 @@ import shop.domain.cart._
 import shop.domain.checkout._
 import shop.domain.item._
 import shop.domain.order._
+import shop.domain.payment._
 import shop.http.clients._
 import squants.market._
 import suite.PureTestSuite
@@ -25,19 +26,19 @@ final class CheckoutSpec extends PureTestSuite {
 
   def successfulClient(paymentId: PaymentId): PaymentClient[IO] =
     new PaymentClient[IO] {
-      def process(userId: UserId, total: Money, card: Card): IO[PaymentId] =
+      def process(payment: Payment): IO[PaymentId] =
         IO.pure(paymentId)
     }
 
   val unreachableClient: PaymentClient[IO] =
     new PaymentClient[IO] {
-      def process(userId: UserId, total: Money, card: Card): IO[PaymentId] =
+      def process(payment: Payment): IO[PaymentId] =
         IO.raiseError(PaymentError(""))
     }
 
   def recoveringClient(attemptsSoFar: Ref[IO, Int], paymentId: PaymentId): PaymentClient[IO] =
     new PaymentClient[IO] {
-      def process(userId: UserId, total: Money, card: Card): IO[PaymentId] =
+      def process(payment: Payment): IO[PaymentId] =
         attemptsSoFar.get.flatMap {
           case n if n.eqv(1) => IO.pure(paymentId)
           case _             => attemptsSoFar.update(_ + 1) *> IO.raiseError(PaymentError(""))


### PR DESCRIPTION
The fake Payments API can be modified here: https://beeceptor.com/console/payments

By default, it returns status 200 with a Payment Id. Users are encouraged to try returning 409 with another valid Payment Id (can create one [here](https://www.uuidgenerator.net/api/version1/1)) or any other status to see how our application handles the different cases.

The Payments client now makes a POST request instead, which seems more realistic than a GET to process a payment. A new `Payment` type has been introduced as well.

- It closes #20 
- It should be merged before #43 