### PR TITLE
simplify the auto derivation of `EntityEncoder`s

### DIFF
--- a/modules/core/src/main/scala/shop/http/json.scala
+++ b/modules/core/src/main/scala/shop/http/json.scala
@@ -23,11 +23,7 @@ import shop.http.auth.users._
 import squants.market._
 
 object json extends JsonCodecs {
-  implicit def jsonEncoder[F[_]: Applicative, A: Encoder]: EntityEncoder[F, A] = jsonEncoderOf[F, A]
-
-  // Should not be necessary but Scala seems not to find the right implicits
-  implicit def paymentEntityEncoder[F[_]: Applicative]: EntityEncoder[F, Payment]     = jsonEncoder[F, Payment]
-  implicit def cartTotalEntityEncoder[F[_]: Applicative]: EntityEncoder[F, CartTotal] = jsonEncoder[F, CartTotal]
+  implicit def deriveEntityEncoder[F[_]: Applicative, A: Encoder]: EntityEncoder[F, A] = jsonEncoderOf[F, A]
 }
 
 private[http] trait JsonCodecs {


### PR DESCRIPTION
I think [this](https://github.com/http4s/http4s/blob/master/circe/src/main/scala/org/http4s/circe/CirceInstances.scala#L91) might be causing a conflict. Simply renaming the method permitted the removal of the specific entity encoders.