### PR TITLE
Macro-friendly assertions using Cats equality

### DIFF
--- a/modules/tests/src/it/scala/shop/algebras/PostgresTest.scala
+++ b/modules/tests/src/it/scala/shop/algebras/PostgresTest.scala
@@ -1,7 +1,7 @@
 package shop.algebras
 
 import cats.effect._
-import cats.implicits._
+import cats.implicits.{ catsSyntaxEq => _, _ }
 import ciris._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
@@ -48,7 +48,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           z <- b.create(brand.name).attempt
         } yield
           assert(
-            x.isEmpty && y.count(_.name.eqv(brand.name)).eqv(1) && z.isLeft
+            x.isEmpty && y.count(_.name === brand.name) === 1 && z.isLeft
           )
       }
     }
@@ -63,7 +63,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           z <- c.create(category.name).attempt
         } yield
           assert(
-            x.isEmpty && y.count(_.name.eqv(category.name)).eqv(1) && z.isLeft
+            x.isEmpty && y.count(_.name === category.name) === 1 && z.isLeft
           )
       }
     }
@@ -94,7 +94,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           y <- i.findAll
         } yield
           assert(
-            x.isEmpty && y.count(_.name.eqv(item.name)).eqv(1)
+            x.isEmpty && y.count(_.name === item.name) === 1
           )
       }
     }
@@ -110,7 +110,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           z <- u.create(username, password).attempt
         } yield
           assert(
-            x.count(_.id.eqv(d)).eqv(1) && y.isEmpty && z.isLeft
+            x.count(_.id === d) === 1 && y.isEmpty && z.isLeft
           )
       }
     }
@@ -127,7 +127,7 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           i <- o.create(d, pid, items, price)
         } yield
           assert(
-            x.isEmpty && y.isEmpty && i.value.version.eqv(4)
+            x.isEmpty && y.isEmpty && i.value.version === 4
           )
       }
     }

--- a/modules/tests/src/main/scala/suite/catseq.scala
+++ b/modules/tests/src/main/scala/suite/catseq.scala
@@ -1,0 +1,25 @@
+package suite
+
+import cats.Eq
+import org.scalactic._
+import org.scalactic.TripleEqualsSupport.AToBEquivalenceConstraint
+import org.scalactic.TripleEqualsSupport.BToAEquivalenceConstraint
+
+// Credits to the original implementation: https://github.com/bvenners/equality-integration-demo
+final class CatsEquivalence[A](ev: Eq[A]) extends Equivalence[A] {
+  def areEquivalent(a: A, b: A): Boolean = ev.eqv(a, b)
+}
+
+trait LowPriorityCatsConstraints extends TripleEquals {
+  implicit def lowPriorityCatsConstraint[A, B](implicit ev1: Eq[B], ev2: A => B): CanEqual[A, B] =
+    new AToBEquivalenceConstraint[A, B](new CatsEquivalence(ev1), ev2)
+}
+
+trait CatsEquality extends LowPriorityCatsConstraints {
+  override def convertToEqualizer[T](left: T): Equalizer[T]                          = super.convertToEqualizer[T](left)
+  implicit override def convertToCheckingEqualizer[T](left: T): CheckingEqualizer[T] = new CheckingEqualizer(left)
+  override def unconstrainedEquality[A, B](implicit equalityOfA: Equality[A]): CanEqual[A, B] =
+    super.unconstrainedEquality[A, B]
+  implicit def bToAConstraint[A, B](implicit ev1: Eq[A], ev2: B => A): CanEqual[A, B] =
+    new BToAEquivalenceConstraint[A, B](new CatsEquivalence(ev1), ev2)
+}

--- a/modules/tests/src/main/scala/suite/http4stest.scala
+++ b/modules/tests/src/main/scala/suite/http4stest.scala
@@ -1,7 +1,6 @@
 package suite
 
 import cats.effect.IO
-import cats.implicits._
 import io.circe._
 import io.circe.syntax._
 import org.http4s._
@@ -19,7 +18,7 @@ trait HttpTestSuite extends PureTestSuite {
     routes.run(req).value.flatMap {
       case Some(resp) =>
         resp.asJson.map { json =>
-          assert(resp.status.eqv(expectedStatus) && json.dropNullValues.eqv(expectedBody.asJson.dropNullValues))
+          assert(resp.status === expectedStatus && json.dropNullValues === expectedBody.asJson.dropNullValues)
         }
       case None => fail("route nout found")
     }
@@ -27,7 +26,7 @@ trait HttpTestSuite extends PureTestSuite {
   def assertHttpStatus(routes: HttpRoutes[IO], req: Request[IO])(expectedStatus: Status) =
     routes.run(req).value.map {
       case Some(resp) =>
-        assert(resp.status.eqv(expectedStatus))
+        assert(resp.status === expectedStatus)
       case None => fail("route nout found")
     }
 

--- a/modules/tests/src/main/scala/suite/puretest.scala
+++ b/modules/tests/src/main/scala/suite/puretest.scala
@@ -2,13 +2,13 @@ package suite
 
 import cats.effect._
 import java.util.UUID
+import org.scalactic.source.Position
 import org.scalatest.compatible.Assertion
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalactic.source.Position
 import scala.concurrent.ExecutionContext
 
-trait PureTestSuite extends AsyncFunSuite with ScalaCheckDrivenPropertyChecks {
+trait PureTestSuite extends AsyncFunSuite with ScalaCheckDrivenPropertyChecks with CatsEquality {
 
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit val timer: Timer[IO]     = IO.timer(ExecutionContext.global)


### PR DESCRIPTION
After realizing that Cats equality doesn't play along with Scalatest's `assert` method, I couldn't sleep well. More on the topic here: https://github.com/functional-streams-for-scala/fs2/pull/1774

This PR introduces a way to use triple equals from Scalactic (used by Scalatest), overriding the equality instance to use Cats' `Eq` typeclass instead.

The only downside is that we cannot have `import cats.implicits._` in scope. We need to hide the equality syntax this way:

```scala
import cats.implicits.{ catsSyntaxEq => _, _ }
```

Credits to the original implementation for Scalaz: https://github.com/bvenners/equality-integration-demo

Thoughts?