### PR TITLE
Fix: persisting order persisting in background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ docs/src/main/tut/contributing.md
 .ignore
 result*
 project/metals.sbt
+.bloop/
+.metals/
+project/.bloop/


### PR DESCRIPTION
Previously, if the order failed to persist on the first schedule it was gone forever since it was not being re-scheduled. This PR fixes this edge case.