### PR TITLE
Updating token expiration on login

### DIFF
--- a/modules/core/src/main/scala/shop/algebras/auth.scala
+++ b/modules/core/src/main/scala/shop/algebras/auth.scala
@@ -108,7 +108,8 @@ final class LiveAuth[F[_]: GenUUID: MonadThrow] private (
       case None => InvalidUserOrPassword(username).raiseError[F, JwtToken]
       case Some(user) =>
         redis.get(username.value).flatMap {
-          case Some(t) => JwtToken(t).pure[F]
+          case Some(t) =>
+            redis.expire(t, TokenExpiration).as(JwtToken(t))
           case None =>
             tokens.create.flatTap { t =>
               redis.setEx(t.value, user.asJson.noSpaces, TokenExpiration) *>


### PR DESCRIPTION
Whenever there's an existing token (user has logged in before), we were returning that token without updating its expiration. This PR fixes that.