### PR TITLE
Improve Codec type safety

### DIFF
--- a/modules/core/src/main/scala/shop/ext/skunk.scala
+++ b/modules/core/src/main/scala/shop/ext/skunk.scala
@@ -7,8 +7,8 @@ import skunk.Codec
 object skunkx {
 
   implicit class CodecOps[B](codec: Codec[B]) {
-    def cimap[A: Coercible[B, *]]: Codec[A] =
-      codec.imap(_.coerce[A])(_.repr.asInstanceOf[B])
+    def cimap[A: Coercible[B, *]](implicit ev: Coercible[A, B]): Codec[A] =
+      codec.imap(_.coerce[A])((ev(_)))
   }
 
 }


### PR DESCRIPTION
:heart: the book. Here is a potential improvement I arrived at while solidifying my understanding of `Coercible`. I could be wrong on any (or all?) points, but either way I would greatly appreciate your feedback. :smile:

---

Fixing a potentially unsafe cast, which `newtype`'s `Coercible` aims to prevent. In practice, `_.repr.asInstanceOf[B]` is safe in that the first leg of the `imap` guarantees a `Coercible[B, A]` instance, which implies the existence of a `Coercible[A, B]` instance, which implies that the cast to `B` is safe. 

Analyzing further, `_.repr.asInstanceOf[B]` is the same as `_.asInstanceOf[B]`. `_.repr` translates to `new CoercibleIdOps(repr = _).repr`, which essentially makes it a no-op, and it doesn't require an implicit evidence parameter.

---

While at it, may I also recommend the use of `R` and `N` as type parameter names (only where it makes sense), as inspired by the following snippet in `newtype`'s documentation:
```scala
/** If we have an Eq instance for Repr type R, derive an Eq instance for  NewType N. */
implicit def coercibleEq[R, N](implicit ev: Coercible[Eq[R], Eq[N]], R: Eq[R]): Eq[N] =
  ev(R)
```
In our case:
```scala
  implicit class CodecOps[R](codec: Codec[R]) {
    def cimap[N: Coercible[R, *]](implicit ev: Coercible[N, R]): Codec[N] =
      codec.imap(_.coerce[N])((ev(_)))
  }
```

Makes it so much easier when making sense of the types. :smile: