### PR TITLE
Fixing false-async tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-ThisBuild / scalaVersion := "2.13.0"
+ThisBuild / scalaVersion := "2.13.1"
 ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / organization := "dev.profunktor"
 ThisBuild / organizationName := "ProfunKtor"

--- a/modules/tests/src/it/scala/shop/algebras/PostgresTest.scala
+++ b/modules/tests/src/it/scala/shop/algebras/PostgresTest.scala
@@ -19,7 +19,7 @@ import shop.domain.item._
 import shop.domain.order._
 import skunk._
 import squants.market.Money
-import suite.ResourceSuite
+import suite._
 
 class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
 
@@ -38,38 +38,40 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
     )
 
   withResources { pool =>
-    forAll(MaxTests) { (brand: Brand) =>
-      spec("Brands") {
-        for {
-          b <- LiveBrands.make[IO](pool)
-          x <- b.findAll
-          _ <- b.create(brand.name)
-          y <- b.findAll
-          z <- b.create(brand.name).attempt
-        } yield
-          assert(
+    test("Brands") {
+      forAll(MaxTests) { (brand: Brand) =>
+        IOAssertion {
+          for {
+            b <- LiveBrands.make[IO](pool)
+            x <- b.findAll
+            _ <- b.create(brand.name)
+            y <- b.findAll
+            z <- b.create(brand.name).attempt
+          } yield assert(
             x.isEmpty && y.count(_.name === brand.name) === 1 && z.isLeft
           )
+        }
       }
     }
 
-    forAll(MaxTests) { (category: Category) =>
-      spec("Categories") {
-        for {
-          c <- LiveCategories.make[IO](pool)
-          x <- c.findAll
-          _ <- c.create(category.name)
-          y <- c.findAll
-          z <- c.create(category.name).attempt
-        } yield
-          assert(
+    test("Categories") {
+      forAll(MaxTests) { (category: Category) =>
+        IOAssertion {
+          for {
+            c <- LiveCategories.make[IO](pool)
+            x <- c.findAll
+            _ <- c.create(category.name)
+            y <- c.findAll
+            z <- c.create(category.name).attempt
+          } yield assert(
             x.isEmpty && y.count(_.name === category.name) === 1 && z.isLeft
           )
+        }
       }
     }
 
-    forAll(MaxTests) { (item: Item) =>
-      spec("Items") {
+    test("Items") {
+      forAll(MaxTests) { (item: Item) =>
         def newItem(
             bid: Option[BrandId],
             cid: Option[CategoryId]
@@ -81,54 +83,58 @@ class PostgresTest extends ResourceSuite[Resource[IO, Session[IO]]] {
           categoryId = cid.getOrElse(item.category.uuid)
         )
 
-        for {
-          b <- LiveBrands.make[IO](pool)
-          c <- LiveCategories.make[IO](pool)
-          i <- LiveItems.make[IO](pool)
-          x <- i.findAll
-          _ <- b.create(item.brand.name)
-          d <- b.findAll.map(_.headOption.map(_.uuid))
-          _ <- c.create(item.category.name)
-          e <- c.findAll.map(_.headOption.map(_.uuid))
-          _ <- i.create(newItem(d, e))
-          y <- i.findAll
-        } yield
-          assert(
+        IOAssertion {
+          for {
+            b <- LiveBrands.make[IO](pool)
+            c <- LiveCategories.make[IO](pool)
+            i <- LiveItems.make[IO](pool)
+            x <- i.findAll
+            _ <- b.create(item.brand.name)
+            d <- b.findAll.map(_.headOption.map(_.uuid))
+            _ <- c.create(item.category.name)
+            e <- c.findAll.map(_.headOption.map(_.uuid))
+            _ <- i.create(newItem(d, e))
+            y <- i.findAll
+          } yield assert(
             x.isEmpty && y.count(_.name === item.name) === 1
           )
+        }
       }
     }
 
-    forAll(MaxTests) { (username: UserName, password: Password) =>
-      spec("Users") {
-        for {
-          c <- LiveCrypto.make[IO](salt)
-          u <- LiveUsers.make[IO](pool, c)
-          d <- u.create(username, password)
-          x <- u.find(username, password)
-          y <- u.find(username, "foo".coerce[Password])
-          z <- u.create(username, password).attempt
-        } yield
-          assert(
+    test("Users") {
+      forAll(MaxTests) { (username: UserName, password: Password) =>
+        IOAssertion {
+          for {
+            c <- LiveCrypto.make[IO](salt)
+            u <- LiveUsers.make[IO](pool, c)
+            d <- u.create(username, password)
+            x <- u.find(username, password)
+            y <- u.find(username, "foo".coerce[Password])
+            z <- u.create(username, password).attempt
+          } yield assert(
             x.count(_.id === d) === 1 && y.isEmpty && z.isLeft
           )
+        }
       }
     }
 
-    forAll(MaxTests) { (oid: OrderId, pid: PaymentId, un: UserName, pw: Password, items: List[CartItem], price: Money) =>
-      spec("Orders") {
-        for {
-          o <- LiveOrders.make[IO](pool)
-          c <- LiveCrypto.make[IO](salt)
-          u <- LiveUsers.make[IO](pool, c)
-          d <- u.create(un, pw)
-          x <- o.findBy(d)
-          y <- o.get(d, oid)
-          i <- o.create(d, pid, items, price)
-        } yield
-          assert(
-            x.isEmpty && y.isEmpty && i.value.version === 4
-          )
+    test("Orders") {
+      forAll(MaxTests) {
+        (oid: OrderId, pid: PaymentId, un: UserName, pw: Password, items: List[CartItem], price: Money) =>
+          IOAssertion {
+            for {
+              o <- LiveOrders.make[IO](pool)
+              c <- LiveCrypto.make[IO](salt)
+              u <- LiveUsers.make[IO](pool, c)
+              d <- u.create(un, pw)
+              x <- o.findBy(d)
+              y <- o.get(d, oid)
+              i <- o.create(d, pid, items, price)
+            } yield assert(
+              x.isEmpty && y.isEmpty && i.value.version === 4
+            )
+          }
       }
     }
 

--- a/modules/tests/src/main/scala/suite/IOAssertion.scala
+++ b/modules/tests/src/main/scala/suite/IOAssertion.scala
@@ -1,0 +1,8 @@
+package suite
+
+import cats.effect.IO
+import cats.syntax.functor._
+
+object IOAssertion {
+  def apply[A](ioa: IO[A]): Unit = ioa.void.unsafeRunSync()
+}

--- a/modules/tests/src/main/scala/suite/puretest.scala
+++ b/modules/tests/src/main/scala/suite/puretest.scala
@@ -1,22 +1,13 @@
 package suite
 
 import cats.effect._
-import java.util.UUID
-import org.scalactic.source.Position
-import org.scalatest.compatible.Assertion
-import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.concurrent.ExecutionContext
 
-trait PureTestSuite extends AsyncFunSuite with ScalaCheckDrivenPropertyChecks with CatsEquality {
+trait PureTestSuite extends AnyFunSuite with ScalaCheckDrivenPropertyChecks with CatsEquality {
 
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit val timer: Timer[IO]     = IO.timer(ExecutionContext.global)
-
-  private def mkUnique(name: String): String =
-    s"$name - ${UUID.randomUUID}"
-
-  def spec(testName: String)(f: => IO[Assertion])(implicit pos: Position): Unit =
-    test(mkUnique(testName))(IO.suspend(f).unsafeToFuture())
 
 }

--- a/modules/tests/src/test/scala/shop/http/routes/BrandRoutesSpec.scala
+++ b/modules/tests/src/test/scala/shop/http/routes/BrandRoutesSpec.scala
@@ -9,7 +9,7 @@ import shop.algebras.Brands
 import shop.arbitraries._
 import shop.domain.brand._
 import shop.http.json._
-import suite.HttpTestSuite
+import suite._
 
 class BrandRoutesSpec extends HttpTestSuite {
 
@@ -23,20 +23,24 @@ class BrandRoutesSpec extends HttpTestSuite {
       IO.raiseError(DummyError) *> IO.pure(brands)
   }
 
-  forAll { (b: List[Brand]) =>
-    spec("GET brands [OK]") {
-      GET(Uri.uri("/brands")).flatMap { req =>
-        val routes = new BrandRoutes[IO](dataBrands(b)).routes
-        assertHttp(routes, req)(Status.Ok, b)
+  test("GET brands [OK]") {
+    forAll { (b: List[Brand]) =>
+      IOAssertion {
+        GET(Uri.uri("/brands")).flatMap { req =>
+          val routes = new BrandRoutes[IO](dataBrands(b)).routes
+          assertHttp(routes, req)(Status.Ok, b)
+        }
       }
     }
   }
 
-  forAll { (b: List[Brand]) =>
-    spec("GET brands [ERROR]") {
-      GET(Uri.uri("/brands")).flatMap { req =>
-        val routes = new BrandRoutes[IO](failingBrands(b)).routes
-        assertHttpFailure(routes, req)
+  test("GET brands [ERROR]") {
+    forAll { (b: List[Brand]) =>
+      IOAssertion {
+        GET(Uri.uri("/brands")).flatMap { req =>
+          val routes = new BrandRoutes[IO](failingBrands(b)).routes
+          assertHttpFailure(routes, req)
+        }
       }
     }
   }

--- a/modules/tests/src/test/scala/shop/http/routes/ItemRoutesSpec.scala
+++ b/modules/tests/src/test/scala/shop/http/routes/ItemRoutesSpec.scala
@@ -10,7 +10,7 @@ import shop.arbitraries._
 import shop.domain.brand._
 import shop.domain.item._
 import shop.http.json._
-import suite.HttpTestSuite
+import suite._
 
 class ItemRoutesSpec extends HttpTestSuite {
 
@@ -26,29 +26,35 @@ class ItemRoutesSpec extends HttpTestSuite {
       findAll
   }
 
-  forAll { (it: List[Item]) =>
-    spec("GET items [OK]") {
-      GET(Uri.uri("/items")).flatMap { req =>
-        val routes = new ItemRoutes[IO](dataItems(it)).routes
-        assertHttp(routes, req)(Status.Ok, it)
+  test("GET items [OK]") {
+    forAll { (it: List[Item]) =>
+      IOAssertion {
+        GET(Uri.uri("/items")).flatMap { req =>
+          val routes = new ItemRoutes[IO](dataItems(it)).routes
+          assertHttp(routes, req)(Status.Ok, it)
+        }
       }
     }
   }
 
-  forAll { (it: List[Item], b: Brand) =>
-    spec("GET items by brand [OK]") {
-      GET(Uri.uri("/items").withQueryParam(b.name.value)).flatMap { req =>
-        val routes = new ItemRoutes[IO](dataItems(it)).routes
-        assertHttp(routes, req)(Status.Ok, it)
+  test("GET items by brand [OK]") {
+    forAll { (it: List[Item], b: Brand) =>
+      IOAssertion {
+        GET(Uri.uri("/items").withQueryParam(b.name.value)).flatMap { req =>
+          val routes = new ItemRoutes[IO](dataItems(it)).routes
+          assertHttp(routes, req)(Status.Ok, it)
+        }
       }
     }
   }
 
-  forAll { (it: List[Item]) =>
-    spec("GET items [ERROR]") {
-      GET(Uri.uri("/items")).flatMap { req =>
-        val routes = new ItemRoutes[IO](failingItems(it)).routes
-        assertHttpFailure(routes, req)
+  test("GET items [ERROR]") {
+    forAll { (it: List[Item]) =>
+      IOAssertion {
+        GET(Uri.uri("/items")).flatMap { req =>
+          val routes = new ItemRoutes[IO](failingItems(it)).routes
+          assertHttpFailure(routes, req)
+        }
       }
     }
   }

--- a/modules/tests/src/test/scala/shop/http/routes/secured/CartRoutesSpec.scala
+++ b/modules/tests/src/test/scala/shop/http/routes/secured/CartRoutesSpec.scala
@@ -15,7 +15,7 @@ import shop.domain.item._
 import shop.http.auth.users._
 import shop.http.json._
 import squants.market.USD
-import suite.HttpTestSuite
+import suite._
 
 class CartRoutesSpec extends HttpTestSuite {
 
@@ -29,20 +29,24 @@ class CartRoutesSpec extends HttpTestSuite {
       IO.pure(cartTotal)
   }
 
-  forAll { (ct: CartTotal) =>
-    spec("GET shopping cart [OK]") {
-      GET(Uri.uri("/cart")).flatMap { req =>
-        val routes = new CartRoutes[IO](dataCart(ct)).routes(authMiddleware)
-        assertHttp(routes, req)(Status.Ok, ct)
+  test("GET shopping cart [OK]") {
+    forAll { (ct: CartTotal) =>
+      IOAssertion {
+        GET(Uri.uri("/cart")).flatMap { req =>
+          val routes = new CartRoutes[IO](dataCart(ct)).routes(authMiddleware)
+          assertHttp(routes, req)(Status.Ok, ct)
+        }
       }
     }
   }
 
-  forAll { (c: Cart) =>
-    spec("POST add item to shopping cart [OK]") {
-      POST(c, Uri.uri("/cart")).flatMap { req =>
-        val routes = new CartRoutes[IO](new TestShoppingCart).routes(authMiddleware)
-        assertHttpStatus(routes, req)(Status.Created)
+  test("POST add item to shopping cart [OK]") {
+    forAll { (c: Cart) =>
+      IOAssertion {
+        POST(c, Uri.uri("/cart")).flatMap { req =>
+          val routes = new CartRoutes[IO](new TestShoppingCart).routes(authMiddleware)
+          assertHttpStatus(routes, req)(Status.Created)
+        }
       }
     }
   }


### PR DESCRIPTION
I recently realized there is a big mistake in our custom test suite. The value of the `Future` was being discarded since the return type is `Unit` and unfortunately, the `scalacOptions` flags didn't catch it (and me neither).

```scala
def spec(testName: String)(f: => IO[Assertion])(implicit pos: Position): Unit =	
    test(mkUnique(testName))(IO.suspend(f).unsafeToFuture())
```

This PR:

- introduces a simple `object IOAssertion` that runs `IO` actions synchronously via `unsafeRunSync`.
- removes the necessity of making unique names for tests by re-ordering what comes first: `test(name)` and then `forAll { ... }`. This is due to `scalacheck` still not supporting asynchronous property checks.
- closes #99 




