### PR TITLE
Upgrading to Cats Effect 2.1.3

### DIFF
--- a/modules/core/src/main/scala/shop/Main.scala
+++ b/modules/core/src/main/scala/shop/Main.scala
@@ -13,7 +13,7 @@ object Main extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] =
     config.load[IO].flatMap { cfg =>
-      Logger[IO].info(s"Loaded config $cfg") *>
+      Logger[IO].info(s"Loaded config $cfg") >>
         AppResources.make[IO](cfg).use { res =>
           for {
             security <- Security.make[IO](cfg, res.psql, res.redis)

--- a/modules/tests/src/main/scala/suite/IOAssertion.scala
+++ b/modules/tests/src/main/scala/suite/IOAssertion.scala
@@ -1,7 +1,6 @@
 package suite
 
 import cats.effect.IO
-import cats.syntax.functor._
 
 object IOAssertion {
   def apply[A](ioa: IO[A]): Unit = ioa.void.unsafeRunSync()

--- a/modules/tests/src/test/scala/shop/http/routes/BrandRoutesSpec.scala
+++ b/modules/tests/src/test/scala/shop/http/routes/BrandRoutesSpec.scala
@@ -1,7 +1,6 @@
 package shop.http.routes
 
 import cats.effect._
-import cats.implicits._
 import org.http4s._
 import org.http4s.Method._
 import org.http4s.client.dsl.io._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Versions {
     val cats          = "2.1.1"
-    val catsEffect    = "2.1.2"
+    val catsEffect    = "2.1.3"
     val catsMeowMtl   = "0.4.0"
     val catsRetry     = "1.1.0"
     val circe         = "0.13.0"


### PR DESCRIPTION
@kubukoz here's a funny one for you. There seems to be a regression after https://github.com/typelevel/cats-effect/pull/804 but I couldn't come up with a minimal reproducible example.

If you change `>>` by `*>` on line 16 in `Main.scala` (the `Logger[IO].info` line) you get a compiler error saying `import cats.implicits._` is not used. If I remove it, the code doesn't compile, though.

It closes #98 . 