### PR TITLE
Adding quote to composer yaml environment variables

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     environment:
       - DEBUG=false
       - SC_ACCESS_TOKEN_SECRET_KEY=5h0pp1ng_k4rt
-      - SC_JWT_SECRET_KEY=-*5h0pp1ng_k4rt*-
-      - SC_JWT_CLAIM={"uuid": "004b4457-71c3-4439-a1b2-03820263b59c"}
+      - "SC_JWT_SECRET_KEY=-*5h0pp1ng_k4rt*-"
+      - 'SC_JWT_CLAIM={"uuid": "004b4457-71c3-4439-a1b2-03820263b59c"}'
       - SC_ADMIN_USER_TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjogIjAwNGI0NDU3LTcxYzMtNDQzOS1hMWIyLTAzODIwMjYzYjU5YyJ9.L97BnPScSAKY-BLkYu8G_n8h1U4LDOURUen14O22hD4
       - SC_PASSWORD_SALT=06!grsnxXG0d*Pj496p6fuA*o
       - SC_APP_ENV=test


### PR DESCRIPTION
If I try to start the the docker composer for the app as described in the README file, I get an error parsing the yaml file. It doesn't appear to be valid yaml, by adding quotes on two lines it fixes the yaml parsing issue and the app starts up.

I don't know if it's the best way to fix this, but I thought I would offer this PR in case it's useful.