### PR TITLE
Updated scala-fmt to 2.7.2 and removed oudated configs

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,13 +1,11 @@
-version                                      = "2.4.2"
-edition                                      = 2019-10
+version                                      = "2.7.2"
 align.openParenCallSite                      = false
 align.tokens                                 = ["%", "%%", {code = "=>", owner = "Case"}, {code = "=", owner = "(Enumerator.Val|Defn.(Va(l|r)|Def|Type))"}, ]
 align.arrowEnumeratorGenerator               = true
 binPack.parentConstructors                   = false
-danglingParentheses                          = true
 maxColumn                                    = 120
-newlines.afterImplicitKWInVerticalMultiline  = true
-newlines.beforeImplicitKWInVerticalMultiline = true
+verticalMultiline.newlineBeforeImplicitKW    = true
+verticalMultiline.newlineAfterImplicitKW     = true
 project.excludeFilters                       = [ .scalafmt.conf ]
 project.git                                  = true
 rewrite.rules                                = [PreferCurlyFors, RedundantBraces, RedundantParens, SortImports]

--- a/modules/core/src/main/scala/shop/Main.scala
+++ b/modules/core/src/main/scala/shop/Main.scala
@@ -23,14 +23,14 @@ object Main extends IOApp {
             programs <- Programs.make[IO](cfg.checkoutConfig, algebras, clients)
             api <- HttpApi.make[IO](algebras, programs, security)
             _ <- BlazeServerBuilder[IO](ExecutionContext.global)
-                  .bindHttp(
-                    cfg.httpServerConfig.port.value,
-                    cfg.httpServerConfig.host.value
-                  )
-                  .withHttpApp(api.httpApp)
-                  .serve
-                  .compile
-                  .drain
+                   .bindHttp(
+                     cfg.httpServerConfig.port.value,
+                     cfg.httpServerConfig.host.value
+                   )
+                   .withHttpApp(api.httpApp)
+                   .serve
+                   .compile
+                   .drain
           } yield ExitCode.Success
         }
     }

--- a/modules/core/src/main/scala/shop/algebras/brands.scala
+++ b/modules/core/src/main/scala/shop/algebras/brands.scala
@@ -44,8 +44,8 @@ final class LiveBrands[F[_]: BracketThrow: GenUUID] private (
 private object BrandQueries {
 
   val codec: Codec[Brand] =
-    (uuid.cimap[BrandId] ~ varchar.cimap[BrandName]).imap {
-      case i ~ n => Brand(i, n)
+    (uuid.cimap[BrandId] ~ varchar.cimap[BrandName]).imap { case i ~ n =>
+      Brand(i, n)
     }(b => b.uuid ~ b.name)
 
   val selectAll: Query[Void, Brand] =

--- a/modules/core/src/main/scala/shop/algebras/categories.scala
+++ b/modules/core/src/main/scala/shop/algebras/categories.scala
@@ -45,8 +45,8 @@ final class LiveCategories[F[_]: BracketThrow: GenUUID] private (
 private object CategoryQueries {
 
   val codec: Codec[Category] =
-    (uuid.cimap[CategoryId] ~ varchar.cimap[CategoryName]).imap {
-      case i ~ n => Category(i, n)
+    (uuid.cimap[CategoryId] ~ varchar.cimap[CategoryName]).imap { case i ~ n =>
+      Category(i, n)
     }(c => c.uuid ~ c.name)
 
   val selectAll: Query[Void, Category] =

--- a/modules/core/src/main/scala/shop/algebras/crypto.scala
+++ b/modules/core/src/main/scala/shop/algebras/crypto.scala
@@ -27,9 +27,8 @@ object LiveCrypto {
         dCipher.value.init(Cipher.DECRYPT_MODE, sKeySpec)
         (eCipher, dCipher)
       }
-      .map {
-        case (ec, dc) =>
-          new LiveCrypto(ec, dc)
+      .map { case (ec, dc) =>
+        new LiveCrypto(ec, dc)
       }
 }
 

--- a/modules/core/src/main/scala/shop/algebras/items.scala
+++ b/modules/core/src/main/scala/shop/algebras/items.scala
@@ -115,9 +115,8 @@ private object ItemQueries {
     sql"""
         INSERT INTO items
         VALUES ($uuid, $varchar, $varchar, $numeric, $uuid, $uuid)
-       """.command.contramap {
-      case id ~ i =>
-        id.value ~ i.name.value ~ i.description.value ~ i.price.amount ~ i.brandId.value ~ i.categoryId.value
+       """.command.contramap { case id ~ i =>
+      id.value ~ i.name.value ~ i.description.value ~ i.price.amount ~ i.brandId.value ~ i.categoryId.value
     }
 
   val updateItem: Command[UpdateItem] =

--- a/modules/core/src/main/scala/shop/algebras/orders.scala
+++ b/modules/core/src/main/scala/shop/algebras/orders.scala
@@ -76,19 +76,17 @@ private object OrderQueries {
   val decoder: Decoder[Order] =
     (
       uuid.cimap[OrderId] ~ uuid ~ uuid.cimap[PaymentId] ~
-          jsonb[Map[ItemId, Quantity]] ~ numeric.map(USD.apply)
-    ).map {
-      case o ~ _ ~ p ~ i ~ t =>
-        Order(o, p, i, t)
+        jsonb[Map[ItemId, Quantity]] ~ numeric.map(USD.apply)
+    ).map { case o ~ _ ~ p ~ i ~ t =>
+      Order(o, p, i, t)
     }
 
   val encoder: Encoder[UserId ~ Order] =
     (
       uuid.cimap[OrderId] ~ uuid.cimap[UserId] ~ uuid.cimap[PaymentId] ~
-          jsonb[Map[ItemId, Quantity]] ~ numeric.contramap[Money](_.amount)
-    ).contramap {
-      case id ~ o =>
-        o.id ~ id ~ o.paymentId ~ o.items ~ o.total
+        jsonb[Map[ItemId, Quantity]] ~ numeric.contramap[Money](_.amount)
+    ).contramap { case id ~ o =>
+      o.id ~ id ~ o.paymentId ~ o.items ~ o.total
     }
 
   val selectByUserId: Query[UserId, Order] =

--- a/modules/core/src/main/scala/shop/algebras/users.scala
+++ b/modules/core/src/main/scala/shop/algebras/users.scala
@@ -48,9 +48,8 @@ final class LiveUsers[F[_]: BracketThrow: GenUUID] private (
           cmd
             .execute(User(id, username) ~ crypto.encrypt(password))
             .as(id)
-            .handleErrorWith {
-              case SqlState.UniqueViolation(_) =>
-                UserNameInUse(username).raiseError[F, UserId]
+            .handleErrorWith { case SqlState.UniqueViolation(_) =>
+              UserNameInUse(username).raiseError[F, UserId]
             }
         }
       }
@@ -61,12 +60,10 @@ final class LiveUsers[F[_]: BracketThrow: GenUUID] private (
 private object UserQueries {
 
   val codec: Codec[User ~ EncryptedPassword] =
-    (uuid.cimap[UserId] ~ varchar.cimap[UserName] ~ varchar.cimap[EncryptedPassword]).imap {
-      case i ~ n ~ p =>
-        User(i, n) ~ p
-    } {
-      case u ~ p =>
-        u.id ~ u.name ~ p
+    (uuid.cimap[UserId] ~ varchar.cimap[UserName] ~ varchar.cimap[EncryptedPassword]).imap { case i ~ n ~ p =>
+      User(i, n) ~ p
+    } { case u ~ p =>
+      u.id ~ u.name ~ p
     }
 
   val selectUser: Query[UserName, User ~ EncryptedPassword] =

--- a/modules/core/src/main/scala/shop/http/params.scala
+++ b/modules/core/src/main/scala/shop/http/params.scala
@@ -12,8 +12,8 @@ object params {
   implicit def coercibleQueryParamDecoder[A: Coercible[B, *], B: QueryParamDecoder]: QueryParamDecoder[A] =
     QueryParamDecoder[B].map(_.coerce[A])
 
-  implicit def refinedQueryParamDecoder[T: QueryParamDecoder, P](
-      implicit ev: Validate[T, P]
+  implicit def refinedQueryParamDecoder[T: QueryParamDecoder, P](implicit
+      ev: Validate[T, P]
   ): QueryParamDecoder[T Refined P] =
     QueryParamDecoder[T].emap(refineV[P](_).leftMap(m => ParseFailure(m, m)))
 

--- a/modules/core/src/main/scala/shop/http/routes/BrandRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/BrandRoutes.scala
@@ -13,9 +13,8 @@ final class BrandRoutes[F[_]: Defer: Monad](
 
   private[routes] val prefixPath = "/brands"
 
-  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] {
-    case GET -> Root =>
-      Ok(brands.findAll)
+  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] { case GET -> Root =>
+    Ok(brands.findAll)
   }
 
   val routes: HttpRoutes[F] = Router(

--- a/modules/core/src/main/scala/shop/http/routes/CategoryRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/CategoryRoutes.scala
@@ -13,9 +13,8 @@ final class CategoryRoutes[F[_]: Defer: Monad](
 
   private[routes] val prefixPath = "/categories"
 
-  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] {
-    case GET -> Root =>
-      Ok(categories.findAll)
+  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] { case GET -> Root =>
+    Ok(categories.findAll)
   }
 
   val routes: HttpRoutes[F] = Router(

--- a/modules/core/src/main/scala/shop/http/routes/HealthRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/HealthRoutes.scala
@@ -13,9 +13,8 @@ final class HealthRoutes[F[_]: Defer: Monad](
 
   private[routes] val prefixPath = "/healthcheck"
 
-  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] {
-    case GET -> Root =>
-      Ok(healthCheck.status)
+  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] { case GET -> Root =>
+    Ok(healthCheck.status)
   }
 
   val routes: HttpRoutes[F] = Router(

--- a/modules/core/src/main/scala/shop/http/routes/ItemRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/ItemRoutes.scala
@@ -17,10 +17,8 @@ final class ItemRoutes[F[_]: Defer: Monad](
 
   object BrandQueryParam extends OptionalQueryParamDecoderMatcher[BrandParam]("brand")
 
-  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] {
-
-    case GET -> Root :? BrandQueryParam(brand) =>
-      Ok(brand.fold(items.findAll)(b => items.findBy(b.toDomain)))
+  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] { case GET -> Root :? BrandQueryParam(brand) =>
+    Ok(brand.fold(items.findAll)(b => items.findBy(b.toDomain)))
 
   }
 

--- a/modules/core/src/main/scala/shop/http/routes/admin/AdminBrandRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/admin/AdminBrandRoutes.scala
@@ -20,11 +20,10 @@ final class AdminBrandRoutes[F[_]: Defer: JsonDecoder: MonadThrow](
   private[admin] val prefixPath = "/brands"
 
   private val httpRoutes: AuthedRoutes[AdminUser, F] =
-    AuthedRoutes.of {
-      case ar @ POST -> Root as _ =>
-        ar.req.decodeR[BrandParam] { bp =>
-          Created(brands.create(bp.toDomain))
-        }
+    AuthedRoutes.of { case ar @ POST -> Root as _ =>
+      ar.req.decodeR[BrandParam] { bp =>
+        Created(brands.create(bp.toDomain))
+      }
     }
 
   def routes(authMiddleware: AuthMiddleware[F, AdminUser]): HttpRoutes[F] = Router(

--- a/modules/core/src/main/scala/shop/http/routes/admin/AdminCategoryRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/admin/AdminCategoryRoutes.scala
@@ -20,11 +20,10 @@ final class AdminCategoryRoutes[F[_]: Defer: JsonDecoder: MonadThrow](
   private[admin] val prefixPath = "/categories"
 
   private val httpRoutes: AuthedRoutes[AdminUser, F] =
-    AuthedRoutes.of {
-      case ar @ POST -> Root as _ =>
-        ar.req.decodeR[CategoryParam] { c =>
-          Created(categories.create(c.toDomain))
-        }
+    AuthedRoutes.of { case ar @ POST -> Root as _ =>
+      ar.req.decodeR[CategoryParam] { c =>
+        Created(categories.create(c.toDomain))
+      }
     }
 
   def routes(authMiddleware: AuthMiddleware[F, AdminUser]): HttpRoutes[F] = Router(

--- a/modules/core/src/main/scala/shop/http/routes/auth/LoginRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/auth/LoginRoutes.scala
@@ -18,17 +18,15 @@ final class LoginRoutes[F[_]: Defer: JsonDecoder: MonadThrow](
 
   private[routes] val prefixPath = "/auth"
 
-  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] {
-
-    case req @ POST -> Root / "login" =>
-      req.decodeR[LoginUser] { user =>
-        auth
-          .login(user.username.toDomain, user.password.toDomain)
-          .flatMap(Ok(_))
-          .recoverWith {
-            case InvalidUserOrPassword(_) => Forbidden()
-          }
-      }
+  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] { case req @ POST -> Root / "login" =>
+    req.decodeR[LoginUser] { user =>
+      auth
+        .login(user.username.toDomain, user.password.toDomain)
+        .flatMap(Ok(_))
+        .recoverWith { case InvalidUserOrPassword(_) =>
+          Forbidden()
+        }
+    }
 
   }
 

--- a/modules/core/src/main/scala/shop/http/routes/auth/LogoutRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/auth/LogoutRoutes.scala
@@ -15,12 +15,10 @@ final class LogoutRoutes[F[_]: Defer: Monad](
 
   private[routes] val prefixPath = "/auth"
 
-  private val httpRoutes: AuthedRoutes[CommonUser, F] = AuthedRoutes.of {
-
-    case ar @ POST -> Root / "logout" as user =>
-      AuthHeaders
-        .getBearerToken(ar.req)
-        .traverse_(t => auth.logout(t, user.value.name)) *> NoContent()
+  private val httpRoutes: AuthedRoutes[CommonUser, F] = AuthedRoutes.of { case ar @ POST -> Root / "logout" as user =>
+    AuthHeaders
+      .getBearerToken(ar.req)
+      .traverse_(t => auth.logout(t, user.value.name)) *> NoContent()
 
   }
 

--- a/modules/core/src/main/scala/shop/http/routes/auth/UserRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/auth/UserRoutes.scala
@@ -18,18 +18,16 @@ final class UserRoutes[F[_]: Defer: JsonDecoder: MonadThrow](
 
   private[routes] val prefixPath = "/auth"
 
-  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] {
-
-    case req @ POST -> Root / "users" =>
-      req
-        .decodeR[CreateUser] { user =>
-          auth
-            .newUser(user.username.toDomain, user.password.toDomain)
-            .flatMap(Created(_))
-            .recoverWith {
-              case UserNameInUse(u) => Conflict(u.value)
-            }
-        }
+  private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] { case req @ POST -> Root / "users" =>
+    req
+      .decodeR[CreateUser] { user =>
+        auth
+          .newUser(user.username.toDomain, user.password.toDomain)
+          .flatMap(Created(_))
+          .recoverWith { case UserNameInUse(u) =>
+            Conflict(u.value)
+          }
+      }
 
   }
 

--- a/modules/core/src/main/scala/shop/http/routes/secured/CartRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/secured/CartRoutes.scala
@@ -27,9 +27,8 @@ final class CartRoutes[F[_]: Defer: JsonDecoder: Monad](
     case ar @ POST -> Root as user =>
       ar.req.asJsonDecode[Cart].flatMap { cart =>
         cart.items
-          .map {
-            case (id, quantity) =>
-              shoppingCart.add(user.value.id, id, quantity)
+          .map { case (id, quantity) =>
+            shoppingCart.add(user.value.id, id, quantity)
           }
           .toList
           .sequence *> Created()

--- a/modules/core/src/main/scala/shop/http/routes/secured/CheckoutRoutes.scala
+++ b/modules/core/src/main/scala/shop/http/routes/secured/CheckoutRoutes.scala
@@ -21,24 +21,22 @@ final class CheckoutRoutes[F[_]: Defer: JsonDecoder: MonadThrow](
 
   private[routes] val prefixPath = "/checkout"
 
-  private val httpRoutes: AuthedRoutes[CommonUser, F] = AuthedRoutes.of {
-
-    case ar @ POST -> Root as user =>
-      ar.req.decodeR[Card] { card =>
-        program
-          .checkout(user.value.id, card)
-          .flatMap(Created(_))
-          .recoverWith {
-            case CartNotFound(userId) =>
-              NotFound(s"Cart not found for user: ${userId.value}")
-            case EmptyCartError =>
-              BadRequest("Shopping cart is empty!")
-            case PaymentError(cause) =>
-              BadRequest(cause)
-            case OrderError(cause) =>
-              BadRequest(cause)
-          }
-      }
+  private val httpRoutes: AuthedRoutes[CommonUser, F] = AuthedRoutes.of { case ar @ POST -> Root as user =>
+    ar.req.decodeR[Card] { card =>
+      program
+        .checkout(user.value.id, card)
+        .flatMap(Created(_))
+        .recoverWith {
+          case CartNotFound(userId) =>
+            NotFound(s"Cart not found for user: ${userId.value}")
+          case EmptyCartError =>
+            BadRequest("Shopping cart is empty!")
+          case PaymentError(cause) =>
+            BadRequest(cause)
+          case OrderError(cause) =>
+            BadRequest(cause)
+        }
+    }
 
   }
 

--- a/modules/core/src/main/scala/shop/modules/HttpApi.scala
+++ b/modules/core/src/main/scala/shop/modules/HttpApi.scala
@@ -62,9 +62,9 @@ final class HttpApi[F[_]: Concurrent: Timer] private (
   // Combining all the http routes
   private val openRoutes: HttpRoutes[F] =
     healthRoutes <+> itemRoutes <+> brandRoutes <+>
-        categoryRoutes <+> loginRoutes <+> userRoutes <+>
-        logoutRoutes <+> cartRoutes <+> orderRoutes <+>
-        checkoutRoutes
+      categoryRoutes <+> loginRoutes <+> userRoutes <+>
+      logoutRoutes <+> cartRoutes <+> orderRoutes <+>
+      checkoutRoutes
 
   private val adminRoutes: HttpRoutes[F] =
     adminItemRoutes <+> adminBrandRoutes <+> adminCategoryRoutes

--- a/modules/tests/src/test/scala/shop/programs/CheckoutSpec.scala
+++ b/modules/tests/src/test/scala/shop/programs/CheckoutSpec.scala
@@ -149,9 +149,9 @@ final class CheckoutSpec extends PureTestSuite {
                     case (c, (x :: y :: xs)) =>
                       assert(
                         x.contains("Rescheduling") &&
-                          y.contains("Giving up") &&
-                          xs.size === MaxRetries &&
-                          c === 1
+                        y.contains("Giving up") &&
+                        xs.size === MaxRetries &&
+                        c === 1
                       )
                     case _ => fail(s"Expected $MaxRetries retries and reschedule")
                   }


### PR DESCRIPTION
As title says this PR removes the [outdated](https://scalameta.org/scalafmt/docs/configuration.html#edition) edition setting and `newlines.afterImplicitKWInVerticalMultiline`, `newlines.beforeImplicitKWInVerticalMultiline` in scala-fmt that were causing the failure in these closed PRs: #179 , #182 , #185. 
This should enable scala-fmt auto dependency updates for the next versions.