### PR TITLE
Refactor secrets

### DIFF
--- a/modules/core/src/main/scala/shop/algebras/crypto.scala
+++ b/modules/core/src/main/scala/shop/algebras/crypto.scala
@@ -18,14 +18,14 @@ trait Crypto {
 }
 
 object Crypto {
-  def make[F[_]: Sync](secret: PasswordSalt): F[Crypto] =
+  def make[F[_]: Sync](passwordSalt: PasswordSalt): F[Crypto] =
     Sync[F]
       .delay {
         val random  = new SecureRandom()
         val ivBytes = new Array[Byte](16)
         random.nextBytes(ivBytes)
         val iv       = new IvParameterSpec(ivBytes);
-        val salt     = secret.value.value.getBytes("UTF-8")
+        val salt     = passwordSalt.secret.value.getBytes("UTF-8")
         val keySpec  = new PBEKeySpec("password".toCharArray(), salt, 65536, 256)
         val factory  = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
         val bytes    = factory.generateSecret(keySpec).getEncoded

--- a/modules/core/src/main/scala/shop/algebras/tokens.scala
+++ b/modules/core/src/main/scala/shop/algebras/tokens.scala
@@ -6,6 +6,7 @@ import shop.effects._
 import cats.Monad
 import cats.syntax.all._
 import dev.profunktor.auth.jwt._
+import eu.timepit.refined.auto._
 import io.circe.syntax._
 import pdi.jwt._
 
@@ -24,7 +25,7 @@ object Tokens {
         for {
           uuid <- GenUUID[F].make
           claim <- jwtExpire.expiresIn(JwtClaim(uuid.asJson.noSpaces), exp)
-          secretKey = JwtSecretKey(config.value.value.value)
+          secretKey = JwtSecretKey(config.secret.value)
           token <- jwtEncode[F](claim, secretKey, JwtAlgorithm.HS256)
         } yield token
     }

--- a/modules/core/src/main/scala/shop/config/data.scala
+++ b/modules/core/src/main/scala/shop/config/data.scala
@@ -10,12 +10,12 @@ import io.estatico.newtype.macros.newtype
 
 object data {
 
-  @newtype case class AdminUserTokenConfig(value: Secret[NonEmptyString])
-  @newtype case class JwtSecretKeyConfig(value: Secret[NonEmptyString])
-  @newtype case class JwtClaimConfig(value: Secret[NonEmptyString])
+  @newtype case class AdminUserTokenConfig(secret: Secret[NonEmptyString])
+  @newtype case class JwtSecretKeyConfig(secret: Secret[NonEmptyString])
+  @newtype case class JwtClaimConfig(secret: Secret[NonEmptyString])
   @newtype case class TokenExpiration(value: FiniteDuration)
 
-  @newtype case class PasswordSalt(value: Secret[NonEmptyString])
+  @newtype case class PasswordSalt(secret: Secret[NonEmptyString])
 
   @newtype case class ShoppingCartExpiration(value: FiniteDuration)
 

--- a/modules/core/src/main/scala/shop/modules/Security.scala
+++ b/modules/core/src/main/scala/shop/modules/Security.scala
@@ -10,6 +10,7 @@ import cats.effect._
 import cats.syntax.all._
 import dev.profunktor.auth.jwt._
 import dev.profunktor.redis4cats.RedisCommands
+import eu.timepit.refined.auto._
 import io.circe.parser.{ decode => jsonDecode }
 import pdi.jwt._
 import skunk.Session
@@ -25,7 +26,7 @@ object Security {
       AdminJwtAuth(
         JwtAuth
           .hmac(
-            cfg.adminJwtConfig.secretKey.value.value.value,
+            cfg.adminJwtConfig.secretKey.secret.value,
             JwtAlgorithm.HS256
           )
       )
@@ -34,12 +35,12 @@ object Security {
       UserJwtAuth(
         JwtAuth
           .hmac(
-            cfg.tokenConfig.value.value.value,
+            cfg.tokenConfig.secret.value,
             JwtAlgorithm.HS256
           )
       )
 
-    val adminToken = JwtToken(cfg.adminJwtConfig.adminToken.value.value.value)
+    val adminToken = JwtToken(cfg.adminJwtConfig.adminToken.secret.value)
 
     for {
       adminClaim <- jwtDecode[F](adminToken, adminJwtAuth.value)


### PR DESCRIPTION
Avoid the ugly `.value.value.value` by renaming to `secret` and using implicit conversion provided by Refined.