### PR TITLE
Remove Async constraint and update redis4cats

### DIFF
--- a/modules/core/src/main/scala/shop/Main.scala
+++ b/modules/core/src/main/scala/shop/Main.scala
@@ -4,6 +4,7 @@ import shop.modules._
 
 import cats.effect._
 import cats.effect.std.Supervisor
+import dev.profunktor.redis4cats.log4cats._
 import eu.timepit.refined.auto._
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Server

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     val log4cats      = "2.0.0"
     val newtype       = "0.4.4"
     val refined       = "0.9.22"
-    val redis4cats    = "1.0.0RC1"
+    val redis4cats    = "1.0.0-RC2"
     val skunk         = "0.1.0"
     val squants       = "1.7.4"
 


### PR DESCRIPTION
In practice, we wil more likely use `Async` directly for resources creation but this demonstrates that it is not the only option.