### PR TITLE
Add ResourceSuite

### DIFF
--- a/modules/tests/src/it/scala/shop/storage/PostgresSuite.scala
+++ b/modules/tests/src/it/scala/shop/storage/PostgresSuite.scala
@@ -14,8 +14,6 @@ import cats.implicits._
 import ciris._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
-import eu.timepit.refined.types.string.NonEmptyString
-import io.estatico.newtype.ops._
 import natchez.Trace.Implicits.noop
 import org.scalacheck.Gen
 import skunk._
@@ -24,7 +22,7 @@ import suite.ResourceSuite
 
 object PostgresSuite extends ResourceSuite {
 
-  lazy val salt = Secret("53kr3t": NonEmptyString).coerce[PasswordSalt]
+  val salt = PasswordSalt(Secret("53kr3t"))
 
   val flushTables: List[Command[Void]] =
     List("items", "brands", "categories", "orders", "users").map { table =>

--- a/modules/tests/src/it/scala/shop/storage/RedisSuite.scala
+++ b/modules/tests/src/it/scala/shop/storage/RedisSuite.scala
@@ -25,7 +25,6 @@ import dev.profunktor.redis4cats.log4cats._
 import dev.profunktor.redis4cats.{ Redis, RedisCommands }
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
-import eu.timepit.refined.types.string.NonEmptyString
 import org.typelevel.log4cats.noop.NoOpLogger
 import pdi.jwt._
 import suite.ResourceSuite
@@ -41,11 +40,11 @@ object RedisSuite extends ResourceSuite {
       .utf8("redis://localhost")
       .beforeAll(_.flushAll)
 
-  lazy val Exp         = ShoppingCartExpiration(30.seconds)
-  lazy val tokenConfig = JwtSecretKeyConfig(Secret("bar": NonEmptyString))
-  lazy val tokenExp    = TokenExpiration(30.seconds)
-  lazy val jwtClaim    = JwtClaim("test")
-  lazy val userJwtAuth = UserJwtAuth(JwtAuth.hmac("bar", JwtAlgorithm.HS256))
+  val Exp         = ShoppingCartExpiration(30.seconds)
+  val tokenConfig = JwtSecretKeyConfig(Secret("bar"))
+  val tokenExp    = TokenExpiration(30.seconds)
+  val jwtClaim    = JwtClaim("test")
+  val userJwtAuth = UserJwtAuth(JwtAuth.hmac("bar", JwtAlgorithm.HS256))
 
   test("Shopping Cart") { cmd =>
     val gen = for {
@@ -83,7 +82,7 @@ object RedisSuite extends ResourceSuite {
     }
   }
 
-  private val salt = PasswordSalt(Secret("test": NonEmptyString))
+  private val salt = PasswordSalt(Secret("test"))
 
   test("Authentication") { cmd =>
     val gen = for {

--- a/modules/tests/src/it/scala/shop/storage/RedisSuite.scala
+++ b/modules/tests/src/it/scala/shop/storage/RedisSuite.scala
@@ -16,7 +16,6 @@ import shop.generators._
 import shop.http.auth.users._
 import shop.services._
 
-import cats.Eq
 import cats.effect._
 import cats.effect.kernel.Ref
 import cats.implicits._
@@ -29,19 +28,18 @@ import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString
 import org.typelevel.log4cats.noop.NoOpLogger
 import pdi.jwt._
-import weaver.IOSuite
-import weaver.scalacheck.{ CheckConfig, Checkers }
+import suite.ResourceSuite
 
-object RedisTest extends IOSuite with Checkers {
-
-  // For it:tests, one test is enough
-  override def checkConfig: CheckConfig = CheckConfig.default.copy(minimumSuccessful = 1)
+object RedisSuite extends ResourceSuite {
 
   implicit val logger = NoOpLogger[IO]
 
-  override type Res = RedisCommands[IO, String, String]
+  type Res = RedisCommands[IO, String, String]
+
   override def sharedResource: Resource[IO, Res] =
-    Redis[IO].utf8("redis://localhost")
+    Redis[IO]
+      .utf8("redis://localhost")
+      .beforeAll(_.flushAll)
 
   lazy val Exp         = ShoppingCartExpiration(30.seconds)
   lazy val tokenConfig = JwtSecretKeyConfig(Secret("bar": NonEmptyString))
@@ -54,8 +52,8 @@ object RedisTest extends IOSuite with Checkers {
       uid <- userIdGen
       it1 <- itemGen
       it2 <- itemGen
-      q1 <- quantityGen
-      q2 <- quantityGen
+      q1  <- quantityGen
+      q2  <- quantityGen
     } yield (uid, it1, it2, q1, q2)
 
     forall(gen) {
@@ -91,7 +89,7 @@ object RedisTest extends IOSuite with Checkers {
     val gen = for {
       un1 <- userNameGen
       un2 <- userNameGen
-      pw <- passwordGen
+      pw  <- passwordGen
     } yield (un1, un2, pw)
 
     forall(gen) {
@@ -121,8 +119,7 @@ object RedisTest extends IOSuite with Checkers {
 
 protected class TestUsers(un: UserName) extends Users[IO] {
   def find(username: UserName): IO[Option[UserWithPassword]] = IO.pure {
-    Eq[UserName]
-      .eqv(username, un)
+    (username === un)
       .guard[Option]
       .as(UserWithPassword(UserId(UUID.randomUUID), un, EncryptedPassword("foo")))
   }

--- a/modules/tests/src/main/scala/suite/ResourceSuite.scala
+++ b/modules/tests/src/main/scala/suite/ResourceSuite.scala
@@ -1,0 +1,24 @@
+package suite
+
+import cats.effect._
+import weaver.IOSuite
+import weaver.scalacheck.{ CheckConfig, Checkers }
+
+abstract class ResourceSuite extends IOSuite with Checkers {
+
+  // For it:tests, one test is enough
+  override def checkConfig: CheckConfig = CheckConfig.default.copy(minimumSuccessful = 1)
+
+  implicit class SharedResOps(res: Resource[IO, Res]) {
+    def beforeAll(f: Res => IO[Unit]): Resource[IO, Res] =
+      res.evalTap(f)
+
+    def afterAll(f: Res => IO[Unit]): Resource[IO, Res] =
+      for {
+        p <- Resource.eval(Deferred[IO, Unit])
+        x <- res.onFinalize(p.complete(()).void)
+        _ <- p.get.background.onFinalize(f(x))
+      } yield x
+  }
+
+}

--- a/modules/tests/src/main/scala/suite/ResourceSuite.scala
+++ b/modules/tests/src/main/scala/suite/ResourceSuite.scala
@@ -21,10 +21,16 @@ abstract class ResourceSuite extends IOSuite with Checkers {
       } yield x
   }
 
-  def testAfterEach(name: String)(afterEach: Res => IO[Unit])(fa: Res => IO[Expectations]): Unit =
-    test(name)(res => fa(res) <* afterEach(res))
+  def testBeforeAfterEach(
+      before: Res => IO[Unit],
+      after: Res => IO[Unit]
+  ): String => (Res => IO[Expectations]) => Unit =
+    name => fa => test(name)(res => before(res) *> fa(res) <* after(res))
 
-  def testBeforeEach(name: String)(beforeEach: Res => IO[Unit])(fa: Res => IO[Expectations]): Unit =
-    test(name)(res => beforeEach(res) *> fa(res))
+  def testAfterEach(after: Res => IO[Unit]): String => (Res => IO[Expectations]) => Unit =
+    testBeforeAfterEach(_ => IO.unit, after)
+
+  def testBeforeEach(before: Res => IO[Unit]): String => (Res => IO[Expectations]) => Unit =
+    testBeforeAfterEach(before, _ => IO.unit)
 
 }

--- a/modules/tests/src/main/scala/suite/ResourceSuite.scala
+++ b/modules/tests/src/main/scala/suite/ResourceSuite.scala
@@ -1,8 +1,8 @@
 package suite
 
 import cats.effect._
-import weaver.IOSuite
 import weaver.scalacheck.{ CheckConfig, Checkers }
+import weaver.{ Expectations, IOSuite }
 
 abstract class ResourceSuite extends IOSuite with Checkers {
 
@@ -20,5 +20,11 @@ abstract class ResourceSuite extends IOSuite with Checkers {
         _ <- p.get.background.onFinalize(f(x))
       } yield x
   }
+
+  def testAfterEach(name: String)(afterEach: Res => IO[Unit])(fa: Res => IO[Expectations]): Unit =
+    test(name)(res => fa(res) <* afterEach(res))
+
+  def testBeforeEach(name: String)(beforeEach: Res => IO[Unit])(fa: Res => IO[Expectations]): Unit =
+    test(name)(res => beforeEach(res) *> fa(res))
 
 }


### PR DESCRIPTION
Introduces both `beforeAll` and `afterAll` as extension methods on resources.

Also `testAfterEach` and `testBeforeEach`, to support the `beforeEach` and `afterEach` functionality without repetition.