### PR TITLE
Update Http4s to 0.23.4

### DIFF
--- a/modules/core/src/main/scala/shop/modules/HttpApi.scala
+++ b/modules/core/src/main/scala/shop/modules/HttpApi.scala
@@ -74,7 +74,9 @@ sealed abstract class HttpApi[F[_]: Async] private (
     { http: HttpRoutes[F] =>
       AutoSlash(http)
     } andThen { http: HttpRoutes[F] =>
-      CORS(http)
+      CORS.policy.withAllowOriginAll
+        .withAllowCredentials(false)
+        .apply(http)
     } andThen { http: HttpRoutes[F] =>
       Timeout(60.seconds)(http)
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val derevo        = "0.12.6"
     val javaxCrypto   = "1.0.1"
     val fs2           = "3.1.3"
-    val http4s        = "0.23.1"
+    val http4s        = "0.23.3"
     val http4sJwtAuth = "1.0.0"
     val log4cats      = "2.1.1"
     val monocle       = "3.1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val derevo        = "0.12.6"
     val javaxCrypto   = "1.0.1"
     val fs2           = "3.1.3"
-    val http4s        = "0.23.3"
+    val http4s        = "0.23.4"
     val http4sJwtAuth = "1.0.0"
     val log4cats      = "2.1.1"
     val monocle       = "3.1.0"


### PR DESCRIPTION
I found that there is a security issue with the current CORS version used in the book:

https://github.com/http4s/http4s/security/advisories/GHSA-52cf-226f-rhr6

I just updated the dependency for http4s and also changed the CORS apply to use the proposed in the previous link, at the migration section.

Of course, I understand that this implies a potential change in the book, at the end of the Modules section in Chapter 9. I leave this here in case it is useful.